### PR TITLE
module to wrap security groups and rules

### DIFF
--- a/aws/ec2/network/data_runtime.tf
+++ b/aws/ec2/network/data_runtime.tf
@@ -1,0 +1,7 @@
+module "data-runtime" {
+  source      = "../security-group"
+  name        = local.names.data_runtime
+  description = local.descriptions.data_runtime
+  tags        = var.tags
+  vpc_id      = var.vpc_id
+}

--- a/aws/ec2/network/data_runtime.tf
+++ b/aws/ec2/network/data_runtime.tf
@@ -4,4 +4,21 @@ module "data-runtime" {
   description = local.descriptions.data_runtime
   tags        = var.tags
   vpc_id      = var.vpc_id
+  aliases     = local.aliases
+
+  ingress = {
+    enable      = var.enable_rules
+    protocol    = var.egress_protocol
+    ports       = local.rules.data_runtime.ingress.ports
+    port_ranges = local.rules.data_runtime.ingress.port_ranges
+    sources     = local.rules.data_runtime.ingress.sources
+  }
+
+  egress = {
+    enable      = var.enable_rules
+    protocol    = var.egress_protocol
+    ports       = local.rules.data_runtime.egress.ports
+    port_ranges = local.rules.data_runtime.egress.port_ranges
+    targets     = local.rules.data_runtime.egress.targets
+  }
 }

--- a/aws/ec2/network/data_runtime.tf
+++ b/aws/ec2/network/data_runtime.tf
@@ -22,3 +22,14 @@ module "data-runtime" {
     targets     = local.rules.data_runtime.egress.targets
   }
 }
+
+module "data-runtime-ingress-linux-runtime" {
+  source      = "../security-group/rule"
+  enable      = local.enable_implicit_rules
+  id          = module.data-runtime.id
+  type        = "ingress"
+  ports       = local.rules.data_runtime.ingress.ports
+  port_ranges = local.rules.data_runtime.ingress.port_ranges
+  sources     = ["linux_runtime"]
+  aliases     = local.default_aliases
+}

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -28,10 +28,14 @@ locals {
   # preprocess rules
   rules_with_keys = { for key in keys(local.names) : key => lookup(var.rules, key, null) }
   rules_with_type = { for key, rule in local.rules_with_keys : key => {
-    for prop in ["ingress", "egress"] : prop => rule != null ? rule[prop] : null
+    for _type in ["ingress", "egress"] : _type => rule != null ? rule[_type] : null
   } }
+  rules = { for key, rule in local.rules_with_type : key => {
+    for _type, leaf in ["ingress", "egress"] : _type => {
+      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => leaf != null ? leaf[prop] : null
+  } } }
 }
 
 output "debug-rules" {
-  value = local.rules_with_type
+  value = local.rules
 }

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -26,5 +26,5 @@ locals {
 
 locals {
   # preprocess rules
-  rules_with_keys = { for key in keys(local.names) : key => lookup(var.rules, key) }
+  rules_with_keys = { for key in keys(local.names) : key => lookup(var.rules, key, null) }
 }

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -16,10 +16,15 @@ locals {
 }
 
 locals {
+  aliases = merge(local.default_aliases, var.aliases)
   default_aliases = {
     load_balancer = module.load-balancer.id
     linux_runtime = module.linux-runtime.id
     data_runtime  = module.data-runtime.id
   }
-  aliases = merge(local.default_aliases, var.aliases)
+}
+
+locals {
+  # preprocess rules
+  rules_with_keys = { for key in keys(local.names) : key => lookup(var.rules, key, {}) }
 }

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -14,3 +14,12 @@ locals {
     data_runtime  = "security group for data runtime"
   })
 }
+
+locals {
+  default_aliases = {
+    load_balancer = module.load-balancer.id
+    linux_runtime = module.linux-runtime.id
+    data_runtime  = module.data-runtime.id
+  }
+  aliases = merge(local.default_aliases, var.aliases)
+}

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -2,40 +2,9 @@ terraform {
   experiments = [module_variable_optional_attrs]
 }
 
-locals {
-  names = defaults(var.names, {
-    load_balancer = "load-balancer"
-    linux_runtime = "linux-runtime"
-    data_runtime  = "data-runtime"
-  })
-  descriptions = defaults(var.descriptions, {
-    load_balancer = "security group for load balancer"
-    linux_runtime = "security group for linux runtime"
-    data_runtime  = "security group for data runtime"
-  })
-}
-
-locals {
-  aliases = merge(local.default_aliases, var.aliases)
-  default_aliases = {
-    load_balancer = module.load-balancer.id
-    linux_runtime = module.linux-runtime.id
-    data_runtime  = module.data-runtime.id
-  }
-}
-
-locals {
-  # preprocess rules
-  rules_with_keys = { for key in keys(local.names) : key => lookup(var.rules, key, null) }
-  rules_with_type = { for key, rule in local.rules_with_keys : key => {
-    for _type in ["ingress", "egress"] : _type => rule != null ? rule[_type] : null
-  } }
-  rules = { for key, rule in local.rules_with_type : key => {
-    for _type, leaf in rule : _type => {
-      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => coalesce(try(leaf[prop], null), [])
-  } } }
-}
-
-locals {
-  enable_implicit_rules = var.enable_rules && var.enable_implicit
+module "custom-rules" {
+  source  = "../security-group/custom-rules"
+  enable  = var.enable_rules
+  aliases = local.aliases
+  rules   = var.rules
 }

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -32,7 +32,7 @@ locals {
   } }
   rules = { for key, rule in local.rules_with_type : key => {
     for _type, leaf in rule : _type => {
-      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => lookup(coalesce(leaf, {}), prop, [])
+      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => try(leaf[prop], [])
   } } }
 }
 

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -32,7 +32,7 @@ locals {
   } }
   rules = { for key, rule in local.rules_with_type : key => {
     for _type, leaf in rule : _type => {
-      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => try(leaf[prop], [])
+      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => coalesce(try(leaf[prop], null), [])
   } } }
 }
 

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -27,9 +27,11 @@ locals {
 locals {
   # preprocess rules
   rules_with_keys = { for key in keys(local.names) : key => lookup(var.rules, key, null) }
-  rules_2         = { for key, rule in local.rules_with_keys : key => rule }
+  rules_with_type = { for key, rule in local.rules_with_keys : key => {
+    for prop in ["ingress", "egress"] : prop => lookup(rule, prop, null)
+  } }
 }
 
 output "debug-rules" {
-  value = local.rules_2
+  value = local.rules_with_type
 }

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -31,7 +31,7 @@ locals {
     for _type in ["ingress", "egress"] : _type => rule != null ? rule[_type] : null
   } }
   rules = { for key, rule in local.rules_with_type : key => {
-    for _type, leaf in ["ingress", "egress"] : _type => {
+    for _type, leaf in rule : _type => {
       for prop in ["ports", "port_ranges", "sources", "targets"] : prop => null
   } } }
 }

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -32,7 +32,7 @@ locals {
   } }
   rules = { for key, rule in local.rules_with_type : key => {
     for _type, leaf in rule : _type => {
-      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => leaf != null ? leaf[prop] : []
+      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => lookup(leaf, prop, [])
   } } }
 }
 

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -8,3 +8,7 @@ module "custom-rules" {
   aliases = local.aliases
   rules   = var.custom_rules
 }
+
+output "x" {
+  value = module.custom-rules
+}

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -14,10 +14,3 @@ locals {
     data_runtime  = "security group for data runtime"
   })
 }
-
-output "debug" {
-  value = {
-    descriptions = local.descriptions
-    rules        = var.rules
-  }
-}

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -1,0 +1,23 @@
+terraform {
+  experiments = [module_variable_optional_attrs]
+}
+
+locals {
+  names = defaults(var.names, {
+    load_balancer = "load-balancer"
+    linux_runtime = "linux-runtime"
+    data_runtime  = "data-runtime"
+  })
+  descriptions = defaults(var.descriptions, {
+    load_balancer = "security group for load balancer"
+    linux_runtime = "security group for linux runtime"
+    data_runtime  = "security group for data runtime"
+  })
+}
+
+output "debug" {
+  value = {
+    descriptions = local.descriptions
+    rules        = var.rules
+  }
+}

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -6,5 +6,5 @@ module "custom-rules" {
   source  = "../security-group/custom-rules"
   enable  = var.enable_rules
   aliases = local.aliases
-  rules   = var.rules
+  rules   = var.custom_rules
 }

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -37,5 +37,5 @@ locals {
 }
 
 output "debug-rules" {
-  value = local.rules
+  value = local.rules_with_type
 }

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -28,7 +28,7 @@ locals {
   # preprocess rules
   rules_with_keys = { for key in keys(local.names) : key => lookup(var.rules, key, null) }
   rules_with_type = { for key, rule in local.rules_with_keys : key => {
-    for prop in ["ingress", "egress"] : prop => lookup(rule, prop, null)
+    for prop in ["ingress", "egress"] : prop => rule != null ? rule[prop] : null
   } }
 }
 

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -26,5 +26,8 @@ locals {
 
 locals {
   # preprocess rules
-  rules_with_keys = { for key in keys(local.names) : key => lookup(var.rules, key, {}) }
+  rules_with_keys = { for key in keys(local.names) : key => lookup(var.rules, key, {
+    ingress = {}
+    egress  = {}
+  }) }
 }

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -27,4 +27,9 @@ locals {
 locals {
   # preprocess rules
   rules_with_keys = { for key in keys(local.names) : key => lookup(var.rules, key, null) }
+  rules_2         = { for key, rule in local.rules_with_keys : key => rule }
+}
+
+output "debug-rules" {
+  value = local.rules_2
 }

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -32,10 +32,10 @@ locals {
   } }
   rules = { for key, rule in local.rules_with_type : key => {
     for _type, leaf in ["ingress", "egress"] : _type => {
-      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => leaf
+      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => null
   } } }
 }
 
 output "debug-rules" {
-  value = local.rules_with_type
+  value = local.rules
 }

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -32,7 +32,7 @@ locals {
   } }
   rules = { for key, rule in local.rules_with_type : key => {
     for _type, leaf in rule : _type => {
-      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => null
+      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => leaf != null ? leaf[prop] : []
   } } }
 }
 

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -32,7 +32,7 @@ locals {
   } }
   rules = { for key, rule in local.rules_with_type : key => {
     for _type, leaf in ["ingress", "egress"] : _type => {
-      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => leaf != null ? leaf[prop] : null
+      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => leaf
   } } }
 }
 

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -32,7 +32,7 @@ locals {
   } }
   rules = { for key, rule in local.rules_with_type : key => {
     for _type, leaf in rule : _type => {
-      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => lookup(leaf, prop, [])
+      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => lookup(coalesce(leaf, {}), prop, [])
   } } }
 }
 

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -36,6 +36,6 @@ locals {
   } } }
 }
 
-output "debug-rules" {
-  value = local.rules
+locals {
+  enable_implicit_rules = var.enable_rules && var.enable_implicit
 }

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -26,8 +26,5 @@ locals {
 
 locals {
   # preprocess rules
-  rules_with_keys = { for key in keys(local.names) : key => lookup(var.rules, key, {
-    ingress = {}
-    egress  = {}
-  }) }
+  rules_with_keys = { for key in keys(local.names) : key => lookup(var.rules, key) }
 }

--- a/aws/ec2/network/default.tf
+++ b/aws/ec2/network/default.tf
@@ -8,7 +8,3 @@ module "custom-rules" {
   aliases = local.aliases
   rules   = var.custom_rules
 }
-
-output "x" {
-  value = module.custom-rules
-}

--- a/aws/ec2/network/interface.tf
+++ b/aws/ec2/network/interface.tf
@@ -13,6 +13,7 @@ variable "names" {
     linux_runtime = optional(string)
     data_runtime  = optional(string)
   })
+  default = {}
 }
 
 variable "descriptions" {
@@ -21,6 +22,7 @@ variable "descriptions" {
     linux_runtime = optional(string)
     data_runtime  = optional(string)
   })
+  default = {}
 }
 
 variable "rules" {

--- a/aws/ec2/network/interface.tf
+++ b/aws/ec2/network/interface.tf
@@ -9,9 +9,9 @@ variable "tags" {
 
 variable "names" {
   type = object({
-    load_balancer = string
-    linux_runtime = string
-    data_runtime  = string
+    load_balancer = optional(string)
+    linux_runtime = optional(string)
+    data_runtime  = optional(string)
   })
 }
 

--- a/aws/ec2/network/interface.tf
+++ b/aws/ec2/network/interface.tf
@@ -13,7 +13,7 @@ variable "names" {
     linux_runtime = optional(string)
     data_runtime  = optional(string)
   })
-  default = null
+  default = {}
 }
 
 variable "descriptions" {
@@ -22,22 +22,27 @@ variable "descriptions" {
     linux_runtime = optional(string)
     data_runtime  = optional(string)
   })
-  default = null
+  default = {}
 }
 
 variable "rules" {
   type = map(
     object({
       ingress = object({
-        ports       = list(number)
-        port_ranges = list(string)
+        ports       = optional(list(number))
+        port_ranges = optional(list(string))
         sources     = list(string)
       })
       egress = object({
-        ports       = list(number)
-        port_ranges = list(string)
+        ports       = optional(list(number))
+        port_ranges = optional(list(string))
         targets     = list(string)
       })
     })
   )
+  default = {}
+  validation {
+    condition     = length([]) == 0
+    error_message = "TBD <bad key> ."
+  }
 }

--- a/aws/ec2/network/interface.tf
+++ b/aws/ec2/network/interface.tf
@@ -47,6 +47,12 @@ variable "rules" {
   }
 }
 
+variable "aliases" {
+  type        = map(string)
+  description = "name -> source"
+  default     = {}
+}
+
 output "security_groups" {
   value = {
     load_balancer = module.load-balancer.id

--- a/aws/ec2/network/interface.tf
+++ b/aws/ec2/network/interface.tf
@@ -13,7 +13,7 @@ variable "names" {
     linux_runtime = optional(string)
     data_runtime  = optional(string)
   })
-  default = {}
+  default = null
 }
 
 variable "descriptions" {
@@ -22,7 +22,7 @@ variable "descriptions" {
     linux_runtime = optional(string)
     data_runtime  = optional(string)
   })
-  default = {}
+  default = null
 }
 
 variable "rules" {

--- a/aws/ec2/network/interface.tf
+++ b/aws/ec2/network/interface.tf
@@ -81,6 +81,19 @@ variable "egress_protocol" {
   }
 }
 
+variable "custom_rules" {
+  type = list(object({
+    type        = string # ingress | egress
+    protocol    = string # tcp | udp | all
+    port        = optional(number)
+    port_range  = optional(string)
+    source      = string
+    target      = string
+    description = optional(string)
+  }))
+  default = []
+}
+
 output "security_groups" {
   value = {
     load_balancer = module.load-balancer.id

--- a/aws/ec2/network/interface.tf
+++ b/aws/ec2/network/interface.tf
@@ -42,7 +42,7 @@ variable "rules" {
   )
   default = {}
   validation {
-    condition     = length([]) == 0
+    condition     = length([for key in keys(var.rules) : key if !contains(["load_balancer", "linux_runtime", "data_runtime"], key)]) == 0
     error_message = "TBD <bad key> ."
   }
 }

--- a/aws/ec2/network/interface.tf
+++ b/aws/ec2/network/interface.tf
@@ -1,0 +1,41 @@
+variable "vpc_id" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "names" {
+  type = object({
+    load_balancer = string
+    linux_runtime = string
+    data_runtime  = string
+  })
+}
+
+variable "descriptions" {
+  type = object({
+    load_balancer = optional(string)
+    linux_runtime = optional(string)
+    data_runtime  = optional(string)
+  })
+}
+
+variable "rules" {
+  type = map(
+    object({
+      ingress = object({
+        ports       = list(number)
+        port_ranges = list(string)
+        sources     = list(string)
+      })
+      egress = object({
+        ports       = list(number)
+        port_ranges = list(string)
+        targets     = list(string)
+      })
+    })
+  )
+}

--- a/aws/ec2/network/interface.tf
+++ b/aws/ec2/network/interface.tf
@@ -28,21 +28,21 @@ variable "descriptions" {
 variable "rules" {
   type = map(
     object({
-      ingress = object({
+      ingress = optional(object({
         ports       = optional(list(number))
         port_ranges = optional(list(string))
         sources     = list(string)
-      })
-      egress = object({
+      }))
+      egress = optional(object({
         ports       = optional(list(number))
         port_ranges = optional(list(string))
         targets     = list(string)
-      })
+      }))
     })
   )
   default = {}
   validation {
     condition     = length([for key in keys(var.rules) : key if !contains(["load_balancer", "linux_runtime", "data_runtime"], key)]) == 0
-    error_message = "TBD <bad key> ."
+    error_message = "Allowed Keys: {load_balancer | linux_runtime | data_runtime}."
   }
 }

--- a/aws/ec2/network/interface.tf
+++ b/aws/ec2/network/interface.tf
@@ -58,6 +58,11 @@ variable "enable_rules" {
   default = true
 }
 
+variable "enable_implicit" {
+  type    = bool
+  default = true
+}
+
 variable "ingress_protocol" {
   type    = string
   default = "tcp"

--- a/aws/ec2/network/interface.tf
+++ b/aws/ec2/network/interface.tf
@@ -46,3 +46,11 @@ variable "rules" {
     error_message = "Allowed Keys: {load_balancer | linux_runtime | data_runtime}."
   }
 }
+
+output "security_groups" {
+  value = {
+    load_balancer = module.load-balancer.id
+    linux_runtime = module.linux-runtime.id
+    data_runtime  = module.data-runtime.id
+  }
+}

--- a/aws/ec2/network/interface.tf
+++ b/aws/ec2/network/interface.tf
@@ -53,6 +53,29 @@ variable "aliases" {
   default     = {}
 }
 
+variable "enable_rules" {
+  type    = bool
+  default = true
+}
+
+variable "ingress_protocol" {
+  type    = string
+  default = "tcp"
+  validation {
+    condition     = contains(["tcp", "udp", "all", "-1"], var.ingress_protocol)
+    error_message = "Allowed Values: {tcp | udp | all}."
+  }
+}
+
+variable "egress_protocol" {
+  type    = string
+  default = "tcp"
+  validation {
+    condition     = contains(["tcp", "udp", "all", "-1"], var.egress_protocol)
+    error_message = "Allowed Values: {tcp | udp | all}."
+  }
+}
+
 output "security_groups" {
   value = {
     load_balancer = module.load-balancer.id

--- a/aws/ec2/network/linux_runtime.tf
+++ b/aws/ec2/network/linux_runtime.tf
@@ -4,4 +4,21 @@ module "linux-runtime" {
   description = local.descriptions.linux_runtime
   tags        = var.tags
   vpc_id      = var.vpc_id
+  aliases     = local.aliases
+
+  ingress = {
+    enable      = var.enable_rules
+    protocol    = var.egress_protocol
+    ports       = local.rules.linux_runtime.ingress.ports
+    port_ranges = local.rules.linux_runtime.ingress.port_ranges
+    sources     = local.rules.linux_runtime.ingress.sources
+  }
+
+  egress = {
+    enable      = var.enable_rules
+    protocol    = var.egress_protocol
+    ports       = local.rules.linux_runtime.egress.ports
+    port_ranges = local.rules.linux_runtime.egress.port_ranges
+    targets     = local.rules.linux_runtime.egress.targets
+  }
 }

--- a/aws/ec2/network/linux_runtime.tf
+++ b/aws/ec2/network/linux_runtime.tf
@@ -1,0 +1,7 @@
+module "linux-runtime" {
+  source      = "../security-group"
+  name        = local.names.linux_runtime
+  description = local.descriptions.linux_runtime
+  tags        = var.tags
+  vpc_id      = var.vpc_id
+}

--- a/aws/ec2/network/linux_runtime.tf
+++ b/aws/ec2/network/linux_runtime.tf
@@ -22,3 +22,25 @@ module "linux-runtime" {
     targets     = local.rules.linux_runtime.egress.targets
   }
 }
+
+module "linux-runtime-ingress-load-balancer" {
+  source      = "../security-group/rule"
+  enable      = local.enable_implicit_rules
+  id          = module.linux-runtime.id
+  type        = "ingress"
+  ports       = local.rules.linux_runtime.ingress.ports
+  port_ranges = local.rules.linux_runtime.ingress.port_ranges
+  sources     = ["load_balancer"]
+  aliases     = local.default_aliases
+}
+
+module "linux-runtime-egress-data-runtime" {
+  source      = "../security-group/rule"
+  enable      = local.enable_implicit_rules
+  id          = module.linux-runtime.id
+  type        = "egress"
+  ports       = local.rules.data_runtime.ingress.ports
+  port_ranges = local.rules.data_runtime.ingress.port_ranges
+  sources     = ["data_runtime"]
+  aliases     = local.default_aliases
+}

--- a/aws/ec2/network/load_balancer.tf
+++ b/aws/ec2/network/load_balancer.tf
@@ -6,11 +6,11 @@ module "load-balancer" {
   vpc_id      = var.vpc_id
   aliases     = local.aliases
 
-  #  ingress = {
-  #    enable      = false
-  #    protocol    = "tcp"
-  #    ports       = local.rules.load_balancer.ingress.ports
-  #    port_ranges = local.rules.load_balancer.ingress.port_ranges
-  #    sources     = local.rules.load_balancer.ingress.sources
-  #  }
+  ingress = {
+    enable      = false
+    protocol    = "tcp"
+    ports       = local.rules.load_balancer.ingress.ports
+    port_ranges = local.rules.load_balancer.ingress.port_ranges
+    sources     = local.rules.load_balancer.ingress.sources
+  }
 }

--- a/aws/ec2/network/load_balancer.tf
+++ b/aws/ec2/network/load_balancer.tf
@@ -1,0 +1,7 @@
+module "load-balancer" {
+  source      = "../security-group"
+  name        = local.names.load_balancer
+  description = local.descriptions.load_balancer
+  tags        = var.tags
+  vpc_id      = var.vpc_id
+}

--- a/aws/ec2/network/load_balancer.tf
+++ b/aws/ec2/network/load_balancer.tf
@@ -16,5 +16,5 @@ module "load-balancer" {
 }
 
 output "debug-lb" {
-  value = var.rules
+  value = var.rules["load_balancer"]
 }

--- a/aws/ec2/network/load_balancer.tf
+++ b/aws/ec2/network/load_balancer.tf
@@ -6,11 +6,11 @@ module "load-balancer" {
   vpc_id      = var.vpc_id
   aliases     = local.aliases
 
-  #  ingress = {
-  #    enable      = false
-  #    protocol    = "tcp"
-  #    ports       = var.rules["load_balancer"].ingress.ports
-  #    port_ranges = var.rules["load_balancer"].ingress.port_ranges
-  #    sources     = var.rules["load_balancer"].ingress.sources
-  #  }
+  ingress = {
+    enable      = false
+    protocol    = "tcp"
+    ports       = local.rules.load_balancer.ingress.ports
+    port_ranges = local.rules.load_balancer.ingress.port_ranges
+    sources     = local.rules.load_balancer.ingress.sources
+  }
 }

--- a/aws/ec2/network/load_balancer.tf
+++ b/aws/ec2/network/load_balancer.tf
@@ -6,11 +6,15 @@ module "load-balancer" {
   vpc_id      = var.vpc_id
   aliases     = local.aliases
 
-  ingress = {
-    enable      = false
-    protocol    = "tcp"
-    ports       = var.rules["load_balancer"].ports
-    port_ranges = var.rules["load_balancer"].port_ranges
-    sources     = var.rules["load_balancer"].sources
-  }
+  #  ingress = {
+  #    enable      = false
+  #    protocol    = "tcp"
+  #    ports       = var.rules["load_balancer"].ports
+  #    port_ranges = var.rules["load_balancer"].port_ranges
+  #    sources     = var.rules["load_balancer"].sources
+  #  }
+}
+
+output "debug-lb" {
+  value = var.rules
 }

--- a/aws/ec2/network/load_balancer.tf
+++ b/aws/ec2/network/load_balancer.tf
@@ -6,11 +6,11 @@ module "load-balancer" {
   vpc_id      = var.vpc_id
   aliases     = local.aliases
 
-  ingress = {
-    enable      = false
-    protocol    = "tcp"
-    ports       = local.rules.load_balancer.ingress.ports
-    port_ranges = local.rules.load_balancer.ingress.port_ranges
-    sources     = local.rules.load_balancer.ingress.sources
-  }
+  #  ingress = {
+  #    enable      = false
+  #    protocol    = "tcp"
+  #    ports       = local.rules.load_balancer.ingress.ports
+  #    port_ranges = local.rules.load_balancer.ingress.port_ranges
+  #    sources     = local.rules.load_balancer.ingress.sources
+  #  }
 }

--- a/aws/ec2/network/load_balancer.tf
+++ b/aws/ec2/network/load_balancer.tf
@@ -6,15 +6,11 @@ module "load-balancer" {
   vpc_id      = var.vpc_id
   aliases     = local.aliases
 
-  #  ingress = {
-  #    enable      = false
-  #    protocol    = "tcp"
-  #    ports       = var.rules["load_balancer"].ports
-  #    port_ranges = var.rules["load_balancer"].port_ranges
-  #    sources     = var.rules["load_balancer"].sources
-  #  }
-}
-
-output "debug-lb" {
-  value = var.rules["load_balancer"].ingress.ports
+  ingress = {
+    enable      = false
+    protocol    = "tcp"
+    ports       = var.rules["load_balancer"].ingress.ports
+    port_ranges = var.rules["load_balancer"].ingress.port_ranges
+    sources     = var.rules["load_balancer"].ingress.sources
+  }
 }

--- a/aws/ec2/network/load_balancer.tf
+++ b/aws/ec2/network/load_balancer.tf
@@ -11,6 +11,6 @@ module "load-balancer" {
     protocol    = "tcp"
     ports       = var.rules["load_balancer"].ports
     port_ranges = var.rules["load_balancer"].port_ranges
-    targets     = var.rules["load_balancer"].targets
+    sources     = var.rules["load_balancer"].sources
   }
 }

--- a/aws/ec2/network/load_balancer.tf
+++ b/aws/ec2/network/load_balancer.tf
@@ -7,16 +7,16 @@ module "load-balancer" {
   aliases     = local.aliases
 
   ingress = {
-    enable      = true
-    protocol    = "tcp"
+    enable      = var.enable_rules
+    protocol    = var.egress_protocol
     ports       = local.rules.load_balancer.ingress.ports
     port_ranges = local.rules.load_balancer.ingress.port_ranges
     sources     = local.rules.load_balancer.ingress.sources
   }
 
   egress = {
-    enable      = true
-    protocol    = "tcp"
+    enable      = var.enable_rules
+    protocol    = var.egress_protocol
     ports       = local.rules.load_balancer.egress.ports
     port_ranges = local.rules.load_balancer.egress.port_ranges
     targets     = local.rules.load_balancer.egress.targets

--- a/aws/ec2/network/load_balancer.tf
+++ b/aws/ec2/network/load_balancer.tf
@@ -14,7 +14,3 @@ module "load-balancer" {
   #    sources     = var.rules["load_balancer"].ingress.sources
   #  }
 }
-
-output "debug-lb" {
-  value = local.rules_with_keys
-}

--- a/aws/ec2/network/load_balancer.tf
+++ b/aws/ec2/network/load_balancer.tf
@@ -16,5 +16,5 @@ module "load-balancer" {
 }
 
 output "debug-lb" {
-  value = var.rules["load_balancer"]
+  value = var.rules["load_balancer"].ingress.ports
 }

--- a/aws/ec2/network/load_balancer.tf
+++ b/aws/ec2/network/load_balancer.tf
@@ -6,11 +6,15 @@ module "load-balancer" {
   vpc_id      = var.vpc_id
   aliases     = local.aliases
 
-  ingress = {
-    enable      = false
-    protocol    = "tcp"
-    ports       = var.rules["load_balancer"].ingress.ports
-    port_ranges = var.rules["load_balancer"].ingress.port_ranges
-    sources     = var.rules["load_balancer"].ingress.sources
-  }
+  #  ingress = {
+  #    enable      = false
+  #    protocol    = "tcp"
+  #    ports       = var.rules["load_balancer"].ingress.ports
+  #    port_ranges = var.rules["load_balancer"].ingress.port_ranges
+  #    sources     = var.rules["load_balancer"].ingress.sources
+  #  }
+}
+
+output "debug-lb" {
+  value = local.rules_with_keys
 }

--- a/aws/ec2/network/load_balancer.tf
+++ b/aws/ec2/network/load_balancer.tf
@@ -11,7 +11,7 @@ module "load-balancer" {
     protocol    = var.egress_protocol
     ports       = local.rules.load_balancer.ingress.ports
     port_ranges = local.rules.load_balancer.ingress.port_ranges
-    sources     = local.rules.load_balancer.ingress.sources
+    sources     = local.load_balancer_ingress_sources
   }
 
   egress = {
@@ -21,4 +21,10 @@ module "load-balancer" {
     port_ranges = local.rules.load_balancer.egress.port_ranges
     targets     = local.rules.load_balancer.egress.targets
   }
+}
+
+locals {
+  load_balancer_ingress_sources = distinct(concat(
+    local.rules.load_balancer.ingress.sources, local.rules.linux_runtime.ingress.sources
+  ))
 }

--- a/aws/ec2/network/load_balancer.tf
+++ b/aws/ec2/network/load_balancer.tf
@@ -4,4 +4,13 @@ module "load-balancer" {
   description = local.descriptions.load_balancer
   tags        = var.tags
   vpc_id      = var.vpc_id
+  aliases     = local.aliases
+
+  ingress = {
+    enable      = false
+    protocol    = "tcp"
+    ports       = var.rules["load_balancer"].ports
+    port_ranges = var.rules["load_balancer"].port_ranges
+    targets     = var.rules["load_balancer"].targets
+  }
 }

--- a/aws/ec2/network/load_balancer.tf
+++ b/aws/ec2/network/load_balancer.tf
@@ -7,10 +7,18 @@ module "load-balancer" {
   aliases     = local.aliases
 
   ingress = {
-    enable      = false
+    enable      = true
     protocol    = "tcp"
     ports       = local.rules.load_balancer.ingress.ports
     port_ranges = local.rules.load_balancer.ingress.port_ranges
     sources     = local.rules.load_balancer.ingress.sources
+  }
+
+  egress = {
+    enable      = true
+    protocol    = "tcp"
+    ports       = local.rules.load_balancer.egress.ports
+    port_ranges = local.rules.load_balancer.egress.port_ranges
+    targets     = local.rules.load_balancer.egress.targets
   }
 }

--- a/aws/ec2/network/locals.tf
+++ b/aws/ec2/network/locals.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 locals {
-  # preprocess rules
+  # preprocess rules to remove undefined or null values
   rules_with_keys = { for key in keys(local.names) : key => lookup(var.rules, key, null) }
   rules_with_type = { for key, rule in local.rules_with_keys : key => {
     for _type in ["ingress", "egress"] : _type => rule != null ? rule[_type] : null

--- a/aws/ec2/network/locals.tf
+++ b/aws/ec2/network/locals.tf
@@ -1,0 +1,37 @@
+locals {
+  names = defaults(var.names, {
+    load_balancer = "load-balancer"
+    linux_runtime = "linux-runtime"
+    data_runtime  = "data-runtime"
+  })
+  descriptions = defaults(var.descriptions, {
+    load_balancer = "security group for load balancer"
+    linux_runtime = "security group for linux runtime"
+    data_runtime  = "security group for data runtime"
+  })
+}
+
+locals {
+  aliases = merge(local.default_aliases, var.aliases)
+  default_aliases = {
+    load_balancer = module.load-balancer.id
+    linux_runtime = module.linux-runtime.id
+    data_runtime  = module.data-runtime.id
+  }
+}
+
+locals {
+  # preprocess rules
+  rules_with_keys = { for key in keys(local.names) : key => lookup(var.rules, key, null) }
+  rules_with_type = { for key, rule in local.rules_with_keys : key => {
+    for _type in ["ingress", "egress"] : _type => rule != null ? rule[_type] : null
+  } }
+  rules = { for key, rule in local.rules_with_type : key => {
+    for _type, leaf in rule : _type => {
+      for prop in ["ports", "port_ranges", "sources", "targets"] : prop => coalesce(try(leaf[prop], null), [])
+  } } }
+}
+
+locals {
+  enable_implicit_rules = var.enable_rules && var.enable_implicit
+}

--- a/aws/ec2/security-group/default.tf
+++ b/aws/ec2/security-group/default.tf
@@ -3,7 +3,7 @@ resource "aws_security_group" "default" {
   name        = var.name
   name_prefix = var.name_prefix
   description = var.description
-  tags        = var.tags
+  tags        = merge(var.tags, { Name = coalesce(var.name, var.name_prefix) })
 }
 
 locals {

--- a/aws/ec2/security-group/interface.tf
+++ b/aws/ec2/security-group/interface.tf
@@ -71,8 +71,9 @@ variable "egress" {
 
 # custom
 variable "aliases" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  description = "name -> source"
+  default     = {}
 }
 
 # outputs


### PR DESCRIPTION
## Related Work
- https://github.com/rkhullar/terraform-modules/pull/7

## Features
- [x] network module

## Future Work
- [ ] vpc lookup construct
- [ ] network construct

## Notes
The network module manages security groups meant for three layers of the tech stack.
- `load_balancer`
- `linux_runtime` application instances (ecs / lambda / ec2)
- `data_runtime` data resources (postgres / redis / atlas)

The module allows the caller to specify the both high level rules for each security group and custom rules for extra flexibility. The module provides control to adds implicit rules, which is enabled by default. An example implicit rule would be to allow egress traffic from the `load_balancer` to `linux_runtime` on the application service port 8000.

If the application instances require internet access, like for sending requests to third parties or updating dependencies, then the caller must explicitly define that egress rule. Perhaps in a future iteration of this module, that rule could be improved upon.