### PR TITLE
upgrade terraform version

### DIFF
--- a/aws/constructs/network/v1/default.tf
+++ b/aws/constructs/network/v1/default.tf
@@ -1,7 +1,3 @@
-terraform {
-  experiments = [module_variable_optional_attrs]
-}
-
 module "default" {
   source           = "../../../ec2/network/v1"
   vpc_id           = local.vpc.id

--- a/aws/constructs/network/v1/interface.tf
+++ b/aws/constructs/network/v1/interface.tf
@@ -45,8 +45,8 @@ variable "aliases" {
 }
 
 variable "enable_rules" {
-  type        = bool
-  default     = true
+  type    = bool
+  default = true
 }
 
 variable "ingress_protocol" {

--- a/aws/constructs/network/v2/default.tf
+++ b/aws/constructs/network/v2/default.tf
@@ -1,7 +1,3 @@
-terraform {
-  experiments = [module_variable_optional_attrs]
-}
-
 module "default" {
   source       = "../../../ec2/network/v2"
   vpc_id       = local.vpc.id

--- a/aws/constructs/network/v2/provider.tf
+++ b/aws/constructs/network/v2/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   # the configuration for this backend will be filled in by terragrunt
   backend "s3" {}
-  required_version = "~> 1.0"
+  required_version = "~> 1.3"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/aws/ec2/network/v1/default.tf
+++ b/aws/ec2/network/v1/default.tf
@@ -1,7 +1,3 @@
-terraform {
-  experiments = [module_variable_optional_attrs]
-}
-
 module "security-groups" {
   for_each    = local.rules
   source      = "../../security-group"

--- a/aws/ec2/network/v2/default.tf
+++ b/aws/ec2/network/v2/default.tf
@@ -1,7 +1,3 @@
-terraform {
-  experiments = [module_variable_optional_attrs]
-}
-
 locals {
   names           = { for name in var.names : name => join("-", compact([var.prefix, name, var.suffix])) }
   descriptions    = { for name in var.names : name => lookup(var.descriptions, name, local.names[name]) }

--- a/aws/ec2/security-group/custom-rules/default.tf
+++ b/aws/ec2/security-group/custom-rules/default.tf
@@ -1,7 +1,3 @@
-terraform {
-  experiments = [module_variable_optional_attrs]
-}
-
 resource "aws_security_group_rule" "default" {
   for_each                 = var.enable ? local.detail_map : {}
   security_group_id        = each.value.group_id

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,12 @@
-## TODO
-- Adopt [defaults function][defaults-function] for complex object type variables once [optional attributes][optional-attributes-experiment] feature is enabled by default.
+## Version Compatibility
+- terraform 1.2 -> modules 0.2
+- terraform 1.3 -> modules 0.3
 
-## Watch
+## Additional Notes
+- [Optional object type attributes][optional-object-type] were experimental in terraform 1.2; generally available as of 1.3.
 - [terragrunt-null-issue]
 
 [defaults-function]: https://www.terraform.io/language/functions/defaults
 [optional-attributes-experiment]: https://www.terraform.io/language/expressions/type-constraints#experimental-optional-object-type-attributes
 [terragrunt-null-issue]: https://github.com/gruntwork-io/terragrunt/issues/892
+[optional-object-type]: https://developer.hashicorp.com/terraform/language/expressions/type-constraints#optional-object-type-attributes


### PR DESCRIPTION
## Description
Removes `module_variable_optional_attrs` and `experiments` for terraform 1.3. Prep for next minor version tag: 0.3.0.

## Additional Notes
The current latest version of terraform is 1.4.5.