### PR TITLE
add example readme for ecs fargate module

### DIFF
--- a/aws/ecs/fargate/readme.md
+++ b/aws/ecs/fargate/readme.md
@@ -1,0 +1,9 @@
+#### Example
+```terraform
+module "cluster" {
+  source                  = "path/to/ecs/fargate"
+  name                    = "cluster-name"
+  capacity_providers      = [{ name = "fargate" }, { name = "fargate-spot" }]
+  enable_default_strategy = false
+}
+```


### PR DESCRIPTION
## NOTE
The `enable_default_strategy` actually defaults to `true` in the module code, but I tested with false so wanted to include the same config in the example.