### PR TITLE
update s3 bucket module; support lifecycle rules

### DIFF
--- a/aws/ec2/load-balancer/access-logs/default.tf
+++ b/aws/ec2/load-balancer/access-logs/default.tf
@@ -4,7 +4,7 @@ module "bucket" {
   tags            = var.tags
   versioning      = var.versioning
   policy          = data.aws_iam_policy_document.default.json
-  lifecycle_rules = coalesce(var.lifecycle_rules, [local.default_lifecycle_rule])
+  lifecycle_rules = coalescelist(var.lifecycle_rules, [local.default_lifecycle_rule])
 }
 
 locals {

--- a/aws/ec2/load-balancer/access-logs/default.tf
+++ b/aws/ec2/load-balancer/access-logs/default.tf
@@ -1,27 +1,15 @@
 module "bucket" {
-  source        = "../../../s3/bucket"
-  name          = var.name
-  tags          = var.tags
-  versioning    = var.versioning
-  access        = "private"
-  policy        = data.aws_iam_policy_document.default.json
-  attach_policy = true
+  source          = "../../../s3/bucket"
+  name            = var.name
+  tags            = var.tags
+  versioning      = var.versioning
+  policy          = data.aws_iam_policy_document.default.json
+  lifecycle_rules = coalesce(var.lifecycle_rules, [local.default_lifecycle_rule])
 }
 
-resource "aws_s3_bucket_ownership_controls" "default" {
-  bucket = module.bucket.output.id
-  rule {
-    object_ownership = "BucketOwnerPreferred"
-  }
-}
-
-resource "aws_s3_bucket_lifecycle_configuration" "default" {
-  bucket = module.bucket.output.id
-  rule {
-    id     = "log-expiration"
-    status = "Enabled"
-    expiration {
-      days = var.expiration
-    }
+locals {
+  default_lifecycle_rule = {
+    id         = "log-expiration"
+    expiration = { days = var.expiration }
   }
 }

--- a/aws/ec2/load-balancer/access-logs/default.tf
+++ b/aws/ec2/load-balancer/access-logs/default.tf
@@ -1,22 +1,14 @@
-resource "aws_s3_bucket" "default" {
-  bucket        = var.name
-  tags          = var.tags
-  force_destroy = true
-}
-
-resource "aws_s3_bucket_public_access_block" "default" {
-  bucket                  = aws_s3_bucket.default.id
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
-resource "aws_s3_bucket_policy" "default" {
-  bucket = aws_s3_bucket.default.id
+module "default" {
+  source = "../../../s3/bucket"
+  name   = var.name
+  tags = var.tags
   policy = data.aws_iam_policy_document.default.json
+  lifecycle = [
+    {id=log-expiration, expiration=var.expiration}
+  ]
 }
 
+/*
 resource "aws_s3_bucket_lifecycle_configuration" "default" {
   bucket = aws_s3_bucket.default.id
   rule {
@@ -27,3 +19,4 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
     }
   }
 }
+*/

--- a/aws/ec2/load-balancer/access-logs/default.tf
+++ b/aws/ec2/load-balancer/access-logs/default.tf
@@ -1,14 +1,22 @@
-module "default" {
-  source = "../../../s3/bucket"
-  name   = var.name
-  tags = var.tags
-  policy = data.aws_iam_policy_document.default.json
-  lifecycle = [
-    {id=log-expiration, expiration=var.expiration}
-  ]
+resource "aws_s3_bucket" "default" {
+  bucket        = var.name
+  tags          = var.tags
+  force_destroy = true
 }
 
-/*
+resource "aws_s3_bucket_public_access_block" "default" {
+  bucket                  = aws_s3_bucket.default.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "default" {
+  bucket = aws_s3_bucket.default.id
+  policy = data.aws_iam_policy_document.default.json
+}
+
 resource "aws_s3_bucket_lifecycle_configuration" "default" {
   bucket = aws_s3_bucket.default.id
   rule {
@@ -19,4 +27,3 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
     }
   }
 }
-*/

--- a/aws/ec2/load-balancer/access-logs/interface.tf
+++ b/aws/ec2/load-balancer/access-logs/interface.tf
@@ -15,12 +15,6 @@ variable "versioning" {
   default  = false
 }
 
-variable "expiration" {
-  type     = number
-  nullable = false
-  default  = 14
-}
-
 variable "prefix" {
   type     = string
   nullable = true
@@ -31,6 +25,18 @@ variable "tags" {
   type     = map(string)
   nullable = false
   default  = {}
+}
+
+variable "expiration" {
+  type     = number
+  nullable = false
+  default  = 14
+}
+
+variable "lifecycle_rules" {
+  default  = []
+  nullable = false
+  type     = list(any)
 }
 
 output "output" {

--- a/aws/ec2/load-balancer/readme.md
+++ b/aws/ec2/load-balancer/readme.md
@@ -1,7 +1,3 @@
-#### TODO
-- [ ] revisit and test access logs module
-  - [ ] adopt s3/bucket module
-
 #### Example
 ```terraform
 locals {

--- a/aws/s3/bucket/default.tf
+++ b/aws/s3/bucket/default.tf
@@ -27,7 +27,7 @@ resource "aws_s3_bucket_acl" "default" {
 }
 
 resource "aws_s3_bucket_policy" "default" {
-  count  = var.attach_policy ? 1 : 0
+  count  = var.attach_policy && var.policy != null ? 1 : 0
   bucket = aws_s3_bucket.default.id
   policy = var.policy
 }

--- a/aws/s3/bucket/default.tf
+++ b/aws/s3/bucket/default.tf
@@ -50,11 +50,11 @@ resource "aws_s3_bucket_cors_configuration" "default" {
   dynamic "cors_rule" {
     for_each = [var.cors_rule]
     content {
-      allowed_headers = lookup(cors_rule.value, "allowed_headers", null)
-      allowed_methods = [for item in cors_rule.value["allowed_methods"] : upper(item)]
-      allowed_origins = cors_rule.value["allowed_origins"]
-      expose_headers  = lookup(cors_rule.value, "expose_headers", null)
-      max_age_seconds = lookup(cors_rule.value, "max_age_seconds", null)
+      allowed_headers = cors_rule.value.allowed_headers
+      allowed_methods = [for item in cors_rule.value.allowed_methods : upper(item)]
+      allowed_origins = cors_rule.value.allowed_origins
+      expose_headers  = cors_rule.value.expose_headers
+      max_age_seconds = cors_rule.value.max_age_seconds
     }
   }
 }

--- a/aws/s3/bucket/default.tf
+++ b/aws/s3/bucket/default.tf
@@ -81,7 +81,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
 
       dynamic "expiration" {
         # NOTE: https://github.com/hashicorp/terraform/issues/28264
-        # for_each = rule.value.expiration != null ? [rule.value.expiration] : []
         for_each = [for item in [rule.value.expiration] : item if item != null]
         content {
           date                         = expiration.value.date
@@ -91,7 +90,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
       }
 
       dynamic "transition" {
-        # for_each = rule.value.transition != null ? rule.value.transition : []
         for_each = rule.value.transition
         content {
           date          = transition.value.date
@@ -101,7 +99,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
       }
 
       dynamic "abort_incomplete_multipart_upload" {
-        # for_each = rule.value.abort_incomplete_multipart_upload != null ? [rule.value.abort_incomplete_multipart_upload] : []
         for_each = [for item in [rule.value.abort_incomplete_multipart_upload] : item if item != null]
         content {
           days_after_initiation = abort_incomplete_multipart_upload.value.days_after_initiation
@@ -109,7 +106,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
       }
 
       dynamic "noncurrent_version_expiration" {
-        # for_each = rule.value.noncurrent_version_expiration != null ? [rule.value.noncurrent_version_expiration] : []
         for_each = [for item in [rule.value.noncurrent_version_expiration] : item if item != null]
         content {
           newer_noncurrent_versions = noncurrent_version_expiration.value.newer_noncurrent_versions
@@ -118,7 +114,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
       }
 
       dynamic "noncurrent_version_transition" {
-        # for_each = rule.value.noncurrent_version_transition != null ? rule.value.noncurrent_version_transition : []
         for_each = rule.value.noncurrent_version_transition
         content {
           newer_noncurrent_versions = noncurrent_version_transition.value.newer_noncurrent_versions

--- a/aws/s3/bucket/default.tf
+++ b/aws/s3/bucket/default.tf
@@ -58,3 +58,22 @@ resource "aws_s3_bucket_cors_configuration" "default" {
     }
   }
 }
+
+resource "aws_s3_bucket_lifecycle_configuration" "default" {
+  count = length(var.lifecycle_rules) > 0 ? 1 : 0
+  bucket = aws_s3_bucket.default.id
+  dynamic "rule" {
+    for_each = var.lifecycle_rules
+    content {
+
+    }
+  }
+
+  rule {
+    id     = "log-expiration"
+    status = "Enabled"
+    expiration {
+      days = var.expiration
+    }
+  }
+}

--- a/aws/s3/bucket/default.tf
+++ b/aws/s3/bucket/default.tf
@@ -75,8 +75,10 @@ locals {
     for key, value in local.lifecycle_rules_with_filter_map[id] : key => value if value != null
   } }
   lifecycle_rules_filter_map_size        = { for id, filter in local.lifecycle_rules_filter_map : id => length(keys(filter)) }
-  lifecycle_rules_with_single_filter_set = [for id in local.lifecycle_rules_with_filter_set : id if local.lifecycle_rules_filter_map_size[id] == 1]
-  lifecycle_rules_with_mixed_filter_set  = [for id in local.lifecycle_rules_with_filter_set : id if local.lifecycle_rules_filter_map_size[id] > 1]
+  lifecycle_rules_filter_tags            = { for id, filter in local.lifecycle_rules_filter_map : id => lookup(filter, "tags", {}) }
+  lifecycle_rules_filter_tags_size       = { for id, tags in local.lifecycle_rules_filter_tags : id => length(tags) }
+  lifecycle_rules_with_single_filter_set = [for id in local.lifecycle_rules_with_filter_set : id if max(local.lifecycle_rules_filter_map_size[id], local.lifecycle_rules_filter_tags_size[id]) == 1]
+  lifecycle_rules_with_mixed_filter_set  = [for id in local.lifecycle_rules_with_filter_set : id if max(local.lifecycle_rules_filter_map_size[id], local.lifecycle_rules_filter_tags_size[id]) > 1]
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "default" {

--- a/aws/s3/bucket/default.tf
+++ b/aws/s3/bucket/default.tf
@@ -80,7 +80,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
       status = rule.value.enable ? "Enabled" : "Disabled"
 
       dynamic "expiration" {
-        for_each = rule.value.expiration != null ? [rule.value.expiration] : []
+        # NOTE: https://github.com/hashicorp/terraform/issues/28264
+        # for_each = rule.value.expiration != null ? [rule.value.expiration] : []
+        for_each = [for item in [rule.value.expiration] : item if item != null]
         content {
           date                         = expiration.value.date
           days                         = expiration.value.days
@@ -89,7 +91,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
       }
 
       dynamic "transition" {
-        for_each = coalesce(rule.value.transition)
+        # for_each = rule.value.transition != null ? rule.value.transition : []
+        for_each = rule.value.transition
         content {
           date          = transition.value.date
           days          = transition.value.days
@@ -98,14 +101,16 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
       }
 
       dynamic "abort_incomplete_multipart_upload" {
-        for_each = rule.value.abort_incomplete_multipart_upload != null ? [rule.value.abort_incomplete_multipart_upload] : []
+        # for_each = rule.value.abort_incomplete_multipart_upload != null ? [rule.value.abort_incomplete_multipart_upload] : []
+        for_each = [for item in [rule.value.abort_incomplete_multipart_upload] : item if item != null]
         content {
           days_after_initiation = abort_incomplete_multipart_upload.value.days_after_initiation
         }
       }
 
       dynamic "noncurrent_version_expiration" {
-        for_each = rule.value.noncurrent_version_expiration != null ? [rule.value.noncurrent_version_expiration] : []
+        # for_each = rule.value.noncurrent_version_expiration != null ? [rule.value.noncurrent_version_expiration] : []
+        for_each = [for item in [rule.value.noncurrent_version_expiration] : item if item != null]
         content {
           newer_noncurrent_versions = noncurrent_version_expiration.value.newer_noncurrent_versions
           noncurrent_days           = noncurrent_version_expiration.value.noncurrent_days
@@ -113,7 +118,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
       }
 
       dynamic "noncurrent_version_transition" {
-        for_each = coalesce(rule.value.noncurrent_version_transition, [])
+        # for_each = rule.value.noncurrent_version_transition != null ? rule.value.noncurrent_version_transition : []
+        for_each = rule.value.noncurrent_version_transition
         content {
           newer_noncurrent_versions = noncurrent_version_transition.value.newer_noncurrent_versions
           noncurrent_days           = noncurrent_version_transition.value.noncurrent_days

--- a/aws/s3/bucket/interface.tf
+++ b/aws/s3/bucket/interface.tf
@@ -82,7 +82,8 @@ variable "force_destroy" {
 }
 
 variable "cors_rule" {
-  nullable = false
+  nullable = true
+  default = null
   type = object({
     allowed_headers = optional(list(string))
     allowed_methods = list(string)
@@ -90,6 +91,18 @@ variable "cors_rule" {
     expose_headers  = optional(list(string))
     max_age_seconds = optional(number)
   })
+}
+
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration#rule
+variable "lifecycle_rules" {
+  nullable = false
+  default = []
+  type = list(object({
+    id=string
+    enable=optional(bool, true)
+    expiration=optional(object({}))
+    filter=optional(object({}))
+  }))
 }
 
 # public access block

--- a/aws/s3/bucket/interface.tf
+++ b/aws/s3/bucket/interface.tf
@@ -11,13 +11,23 @@ variable "tags" {
 }
 
 # access control
+variable "object_ownership" {
+  nullable = false
+  type     = string
+  default  = "BucketOwnerEnforced"
+  validation {
+    condition     = contains(["BucketOwnerPreferred", "ObjectWriter", "BucketOwnerEnforced"], var.object_ownership)
+    error_message = "Allowed Values: {BucketOwnerPreferred | ObjectWriter | BucketOwnerEnforced}."
+  }
+}
+
 variable "access" {
   type        = string
-  nullable    = true
-  default     = null
+  nullable    = false
+  default     = ""
   description = "https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl"
   validation {
-    condition     = contains(["private", "public-read", "public-read-write", "aws-exec-read", "authenticated-read", "bucket-owner-read", "bucket-owner-full-control", "log-delivery-write"], var.access)
+    condition     = contains(["", "private", "public-read", "public-read-write", "aws-exec-read", "authenticated-read", "bucket-owner-read", "bucket-owner-full-control", "log-delivery-write"], var.access)
     error_message = "Allowed Values: {private | public-read | public-read-write | aws-exec-read | authenticated-read | bucket-owner-read | bucket-owner-full-control | log-delivery-write}."
   }
 }
@@ -71,7 +81,7 @@ variable "kms_master_key_id" {
 variable "bucket_key_enabled" {
   type     = bool
   nullable = false
-  default  = false
+  default  = true
 }
 
 # misc

--- a/aws/s3/bucket/interface.tf
+++ b/aws/s3/bucket/interface.tf
@@ -110,7 +110,12 @@ variable "lifecycle_rules" {
   type = list(object({
     id     = string
     enable = optional(bool, true)
-    filter = optional(object({}))
+    filter = optional(object({
+      object_size_greater_than = optional(number)
+      object_size_less_than    = optional(number)
+      prefix                   = optional(string)
+      tags                     = optional(map(string))
+    }))
     expiration = optional(object({
       date                         = optional(string)
       days                         = optional(number)

--- a/aws/s3/bucket/interface.tf
+++ b/aws/s3/bucket/interface.tf
@@ -41,7 +41,7 @@ variable "policy" {
 variable "attach_policy" {
   type     = bool
   nullable = false
-  default  = false
+  default  = true
 }
 
 variable "versioning" {

--- a/aws/s3/bucket/interface.tf
+++ b/aws/s3/bucket/interface.tf
@@ -120,7 +120,7 @@ variable "lifecycle_rules" {
       date          = optional(string)
       days          = optional(number)
       storage_class = string
-    })))
+    })), [])
     abort_incomplete_multipart_upload = optional(object({
       days_after_initiation = number
     }))
@@ -132,7 +132,7 @@ variable "lifecycle_rules" {
       newer_noncurrent_versions = optional(number)
       noncurrent_days           = optional(number)
       storage_class             = string
-    })))
+    })), [])
   }))
 }
 

--- a/aws/s3/bucket/interface.tf
+++ b/aws/s3/bucket/interface.tf
@@ -83,7 +83,7 @@ variable "force_destroy" {
 
 variable "cors_rule" {
   nullable = true
-  default = null
+  default  = null
   type = object({
     allowed_headers = optional(list(string))
     allowed_methods = list(string)
@@ -93,15 +93,36 @@ variable "cors_rule" {
   })
 }
 
-# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration#rule
 variable "lifecycle_rules" {
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration#rule
   nullable = false
-  default = []
+  default  = []
   type = list(object({
-    id=string
-    enable=optional(bool, true)
-    expiration=optional(object({}))
-    filter=optional(object({}))
+    id     = string
+    enable = optional(bool, true)
+    filter = optional(object({}))
+    expiration = optional(object({
+      date                         = optional(string)
+      days                         = optional(number)
+      expired_object_delete_marker = optional(bool)
+    }))
+    transition = optional(list(object({
+      date          = optional(string)
+      days          = optional(number)
+      storage_class = string
+    })))
+    abort_incomplete_multipart_upload = optional(object({
+      days_after_initiation = number
+    }))
+    noncurrent_version_expiration = optional(object({
+      newer_noncurrent_versions = optional(number)
+      noncurrent_days           = optional(number)
+    }))
+    noncurrent_version_transition = optional(list(object({
+      newer_noncurrent_versions = optional(number)
+      noncurrent_days           = optional(number)
+      storage_class             = string
+    })))
   }))
 }
 

--- a/aws/s3/bucket/interface.tf
+++ b/aws/s3/bucket/interface.tf
@@ -1,92 +1,120 @@
 # naming
 variable "name" {
-  type = string
+  type     = string
+  nullable = false
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type     = map(string)
+  nullable = false
+  default  = {}
 }
 
 # access control
 variable "access" {
   type        = string
+  nullable    = true
   default     = null
-  description = "private | public-read | public-read-write | aws-exec-read | authenticated-read | bucket-owner-read | bucket-owner-full-control | log-delivery-write"
-  # https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
+  description = "https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl"
+  validation {
+    condition     = contains(["private", "public-read", "public-read-write", "aws-exec-read", "authenticated-read", "bucket-owner-read", "bucket-owner-full-control", "log-delivery-write"], var.access)
+    error_message = "Allowed Values: {private | public-read | public-read-write | aws-exec-read | authenticated-read | bucket-owner-read | bucket-owner-full-control | log-delivery-write}."
+  }
 }
 
 variable "policy" {
-  type    = string
-  default = null
+  type     = string
+  nullable = true
+  default  = null
 }
 
 variable "attach_policy" {
-  type    = bool
-  default = false
+  type     = bool
+  nullable = false
+  default  = false
 }
 
 variable "versioning" {
-  type    = bool
-  default = true
+  type     = bool
+  nullable = false
+  default  = true
 }
 
 variable "mfa_delete" {
-  type    = bool
-  default = false
+  type     = bool
+  nullable = false
+  default  = false
 }
 
 variable "encryption" {
-  type    = bool
-  default = true
+  type     = bool
+  nullable = false
+  default  = true
 }
 
 variable "algorithm" {
-  type        = string
-  default     = "AES256"
-  description = "AES256 | aws:kms"
+  type     = string
+  nullable = false
+  default  = "AES256"
+  validation {
+    condition     = contains(["AES256", "aws:kms"], var.algorithm)
+    error_message = "Allowed Values: {AES256 | aws:kms}."
+  }
 }
 
 variable "kms_master_key_id" {
-  type    = string
-  default = "aws/s3"
+  type     = string
+  nullable = false
+  default  = "aws/s3"
 }
 
 variable "bucket_key_enabled" {
-  type    = bool
-  default = false
+  type     = bool
+  nullable = false
+  default  = false
 }
 
 # misc
 variable "force_destroy" {
-  type    = bool
-  default = true
+  type     = bool
+  nullable = false
+  default  = true
 }
 
 variable "cors_rule" {
-  type    = any
-  default = null
+  nullable = false
+  type = object({
+    allowed_headers = optional(list(string))
+    allowed_methods = list(string)
+    allowed_origins = list(string)
+    expose_headers  = optional(list(string))
+    max_age_seconds = optional(number)
+  })
 }
 
 # public access block
 variable "block_public_acls" {
-  type    = bool
-  default = true
+  type     = bool
+  nullable = false
+  default  = true
 }
 
 variable "block_public_policy" {
-  type    = bool
-  default = true
+  type     = bool
+  nullable = false
+  default  = true
 }
 
 variable "ignore_public_acls" {
-  type    = bool
-  default = true
+  type     = bool
+  nullable = false
+  default  = true
 }
 
 variable "restrict_public_buckets" {
-  type    = bool
-  default = true
+  type     = bool
+  nullable = false
+  default  = true
 }
 
 # outputs

--- a/aws/s3/bucket/readme.md
+++ b/aws/s3/bucket/readme.md
@@ -1,0 +1,15 @@
+#### Example
+```terraform
+module "bucket" {
+  source = "path/to/s3/bucket"
+  name   = "bucket-name"
+  lifecycle_rules = [
+    {
+      id                                = "test"
+      abort_incomplete_multipart_upload = { days_after_initiation = 7 }
+      expiration                        = { days = 60 }
+      transition                        = [{ days = 30, storage_class = "standard_ia" }]
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Related Links
- [lifecycle rule docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration#rule)
- [reference code](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/96226df43f789bdc4c3c0f2c8306ba0cf8e95605/main.tf#L215-L328)
- [`compact` github issue](https://github.com/hashicorp/terraform/issues/28264)

## Description
- [x] revisit s3 bucket module variable types: define nullables, check default values
- [x] implement support for bucket lifecycle rules
- [x] update load-balancer/access-logs module

### Note on `compact`
While adding the dynamic nested blocks for the lifecycle rule config, I usually check if the object variable data is defined and wrap it a list. For reference see the following two permalinks:
- https://github.com/rkhullar/terraform-modules/blob/9a46a4835ce91c399ec145a4f3e8170a99632262/aws/s3/bucket/interface.tf#L119-L123
- https://github.com/rkhullar/terraform-modules/blob/9a46a4835ce91c399ec145a4f3e8170a99632262/aws/s3/bucket/default.tf#L95-L103

In order to build the `for_each` value for the dynamic block, I would have preferred to use `compact([rule.value.expiration])`. Since that function doesn't support objects, I had to use either of the following patterns instead in multiple places:
- `rule.value.expiration != null ? [rule.value.expiration] : []`
- `[for item in [rule.value.expiration] : item if item != null]`