### PR TITLE
http-api and rest-api

### DIFF
--- a/aws/apigw/http-api/default.tf
+++ b/aws/apigw/http-api/default.tf
@@ -2,51 +2,106 @@ data "aws_lambda_function" "default" {
   function_name = var.lambda_function_name
 }
 
+locals {
+  enable_cors           = length(var.allowed_origins) > 0
+  enable_jwt_authorizer = var.flags.enable_jwt_authorizer && var.jwt_auth != null
+  lambda_arn_parts      = compact([data.aws_lambda_function.default.arn, var.lambda_function_alias])
+  lambda_arn            = join(":", local.lambda_arn_parts)
+}
+
 resource "aws_apigatewayv2_api" "default" {
   name                         = var.name
   tags                         = var.tags
   protocol_type                = "HTTP"
-  disable_execute_api_endpoint = local.flags["disable_default_endpoint"]
+  disable_execute_api_endpoint = var.flags.disable_default_endpoint
+
+  dynamic "cors_configuration" {
+    for_each = local.enable_cors ? [true] : []
+    content {
+      allow_origins = var.allowed_origins
+      allow_methods = var.allowed_methods
+      allow_headers = ["authorization"]
+    }
+  }
 }
 
 resource "aws_apigatewayv2_stage" "default" {
   api_id      = aws_apigatewayv2_api.default.id
   name        = "$default"
   tags        = var.tags
-  auto_deploy = local.flags["auto_deploy"]
+  auto_deploy = var.flags.auto_deploy
+
+  dynamic "access_log_settings" {
+    for_each = var.flags.enable_logs ? [true] : []
+    content {
+      destination_arn = aws_cloudwatch_log_group.default[0].arn
+      format          = jsonencode(var.log_context)
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "default" {
+  count = var.flags.enable_logs ? 1 : 0
+  name  = var.name
+  tags  = var.tags
 }
 
 resource "aws_apigatewayv2_route" "default" {
+  for_each           = var.flags.enable_proxy_route ? var.allowed_methods : []
   api_id             = aws_apigatewayv2_api.default.id
-  route_key          = "$default"
-  authorization_type = local.flags["enable_jwt_authorizer"] ? "JWT" : null
-  authorizer_id      = local.flags["enable_jwt_authorizer"] ? aws_apigatewayv2_authorizer.jwt[0].id : null
+  route_key          = "${upper(each.value)} /{proxy+}"
+  authorization_type = local.enable_jwt_authorizer ? "JWT" : null
+  authorizer_id      = local.enable_jwt_authorizer ? aws_apigatewayv2_authorizer.jwt[0].id : null
   target             = "integrations/${aws_apigatewayv2_integration.default.id}"
 }
 
 resource "aws_apigatewayv2_integration" "default" {
   api_id                 = aws_apigatewayv2_api.default.id
   integration_type       = "AWS_PROXY"
-  integration_uri        = data.aws_lambda_function.default.arn
+  integration_uri        = local.lambda_arn
   payload_format_version = "2.0"
 }
 
 resource "aws_apigatewayv2_authorizer" "jwt" {
-  count            = local.flags["enable_jwt_authorizer"] ? 1 : 0
+  count            = local.enable_jwt_authorizer ? 1 : 0
   api_id           = aws_apigatewayv2_api.default.id
   authorizer_type  = "JWT"
   identity_sources = ["$request.header.Authorization"]
-  name             = coalesce(local.jwt_auth["name"], var.name)
+  name             = var.jwt_auth.name
   jwt_configuration {
-    issuer   = local.jwt_auth["issuer"]
-    audience = [local.jwt_auth["audience"]]
+    issuer   = var.jwt_auth.issuer
+    audience = [var.jwt_auth.audience]
   }
 }
 
 resource "aws_lambda_permission" "default" {
-  count         = local.flags["create_lambda_permission"] ? 1 : 0
+  count         = var.flags.create_lambda_permission && var.flags.enable_proxy_route ? 1 : 0
   action        = "lambda:InvokeFunction"
   function_name = data.aws_lambda_function.default.function_name
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "${aws_apigatewayv2_api.default.execution_arn}/*/$default"
+  source_arn    = "${aws_apigatewayv2_api.default.execution_arn}/$default/*/{proxy+}"
+  qualifier     = var.lambda_function_alias
+}
+
+locals {
+  extra_routes_map = { for item in var.extra_routes : "${upper(item["method"])} ${item["path"]}" => item }
+}
+
+resource "aws_apigatewayv2_route" "extra" {
+  for_each             = local.extra_routes_map
+  api_id               = aws_apigatewayv2_api.default.id
+  route_key            = each.key
+  authorization_type   = each.value["require_jwt"] ? "JWT" : null
+  authorizer_id        = each.value["require_jwt"] ? aws_apigatewayv2_authorizer.jwt[0].id : null
+  authorization_scopes = each.value["scopes"]
+  target               = "integrations/${aws_apigatewayv2_integration.default.id}"
+}
+
+resource "aws_lambda_permission" "extra" {
+  for_each      = var.flags.create_lambda_permission ? local.extra_routes_map : {}
+  action        = "lambda:InvokeFunction"
+  function_name = data.aws_lambda_function.default.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.default.execution_arn}/$default/${upper(each.value["method"])}${each.value["path"]}"
+  qualifier     = var.lambda_function_alias
 }

--- a/aws/apigw/http-api/interface.tf
+++ b/aws/apigw/http-api/interface.tf
@@ -14,51 +14,71 @@ variable "lambda_function_name" {
   nullable = false
 }
 
-variable "flags_default" {
-  nullable = false
-  type = object({
-    auto_deploy              = bool
-    disable_default_endpoint = bool
-    create_lambda_permission = bool
-    enable_jwt_authorizer    = bool
-  })
-  default = {
-    auto_deploy              = true
-    disable_default_endpoint = true
-    create_lambda_permission = true
-    enable_jwt_authorizer    = true
-  }
+variable "lambda_function_alias" {
+  type     = string
+  nullable = true
+  default  = null
 }
 
 variable "flags" {
-  type     = map(bool)
   default  = {}
   nullable = false
+  type = object({
+    auto_deploy              = optional(bool, true)
+    disable_default_endpoint = optional(bool, true)
+    create_lambda_permission = optional(bool, true)
+    enable_jwt_authorizer    = optional(bool, true)
+    enable_proxy_route       = optional(bool, true)
+    enable_logs              = optional(bool, true)
+  })
 }
 
-variable "jwt_auth_default" {
-  nullable = false
+variable "jwt_auth" {
+  default  = null
+  nullable = true
   type = object({
     name     = string
     issuer   = string
     audience = string
   })
-  default = {
-    name     = null
-    issuer   = null
-    audience = null
-  }
 }
 
-variable "jwt_auth" {
-  type     = map(string)
-  default  = {}
+variable "allowed_methods" {
+  type     = set(string)
+  default  = ["get", "post", "put", "delete"]
   nullable = false
 }
 
-locals {
-  flags    = merge(var.flags_default, var.flags)
-  jwt_auth = merge(var.jwt_auth_default, var.jwt_auth)
+variable "allowed_origins" {
+  type     = set(string)
+  default  = []
+  nullable = false
+}
+
+variable "extra_routes" {
+  default  = []
+  nullable = false
+  type = list(object({
+    method      = string
+    path        = string
+    require_jwt = optional(bool, false)
+    scopes      = optional(list(string))
+  }))
+}
+
+variable "log_context" {
+  type     = map(string)
+  nullable = false
+  default = {
+    httpMethod     = "$context.httpMethod"
+    ip             = "$context.identity.sourceIp"
+    protocol       = "$context.protocol"
+    requestId      = "$context.requestId"
+    requestTime    = "$context.requestTime"
+    responseLength = "$context.responseLength"
+    routeKey       = "$context.routeKey"
+    status         = "$context.status"
+  }
 }
 
 # output

--- a/aws/apigw/http-api/interface.tf
+++ b/aws/apigw/http-api/interface.tf
@@ -5,8 +5,8 @@ variable "name" {
 
 variable "tags" {
   type     = map(string)
-  default  = {}
   nullable = false
+  default  = {}
 }
 
 variable "lambda_function_name" {

--- a/aws/apigw/http-api/readme.md
+++ b/aws/apigw/http-api/readme.md
@@ -12,16 +12,20 @@ As a workaround, you can manually detach the authorizer from the route in the AW
 #### Example
 ```terraform
 module "test-api" {
-  source               = "path/to/http-api"
-  name                 = "test-api"
-  lambda_function_name = "test-lambda"
+  source                = "path/to/http-api"
+  name                  = "test-api"
+  lambda_function_name  = "test-lambda"
+  lambda_function_alias = "latest" # optional
+  allowed_origins       = var.allowed_origins
   jwt_auth = {
-    issuer   = var.jwt_auth.issuer
-    audience = var.jwt_auth.audience
+    name     = "auth.example.org"
+    issuer   = "https://auth.example.org/oauth2/default"
+    audience = "api://default"
   }
-  flags = {
-    create_lambda_permission = false
-    enable_jwt_authorizer    = true
-  }
+  extra_routes = [
+    { method = "get",  path = "/docs" },
+    { method = "get",  path = "/debug/auth-state", require_jwt = true },
+    { method = "post", path = "/message", require_jwt = true, scopes = ["message:write"] }
+  ]
 }
 ```

--- a/aws/apigw/http-api/readme.md
+++ b/aws/apigw/http-api/readme.md
@@ -1,5 +1,5 @@
 #### Notes
-By default, this module used jwt authorization. If the api is created with jwt auth enabled, and you need to disable the
+By default, this module uses jwt authorization. If the api is created with jwt auth enabled, and you need to disable the
 auth, then you'll run into this error message:
 
 `ConflictException: Cannot delete authorizer {name}, is referenced in route: $default`

--- a/aws/apigw/rest-api/default.tf
+++ b/aws/apigw/rest-api/default.tf
@@ -1,0 +1,43 @@
+resource "aws_api_gateway_rest_api" "default" {
+  name                         = var.name
+  tags                         = var.tags
+  disable_execute_api_endpoint = var.flags.disable_default_endpoint
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}
+
+resource "aws_api_gateway_deployment" "default" {
+  depends_on  = [module.lambda-integrations]
+  rest_api_id = aws_api_gateway_rest_api.default.id
+}
+
+resource "aws_api_gateway_stage" "default" {
+  rest_api_id   = aws_api_gateway_deployment.default.rest_api_id
+  deployment_id = aws_api_gateway_deployment.default.id
+  stage_name    = "default"
+  tags          = var.tags
+  lifecycle {
+    ignore_changes = [deployment_id, cache_cluster_size]
+  }
+}
+
+resource "aws_api_gateway_resource" "default" {
+  for_each    = toset(distinct([for route in var.routes : route["path"]]))
+  rest_api_id = aws_api_gateway_rest_api.default.id
+  parent_id   = aws_api_gateway_rest_api.default.root_resource_id
+  path_part   = trimprefix(each.value, "/")
+}
+
+module "lambda-integrations" {
+  depends_on       = [aws_api_gateway_resource.default]
+  for_each         = { for route in var.routes : "${upper(route["method"])} ${route["path"]}" => route }
+  source           = "./lambda-integration"
+  rest_api_name    = aws_api_gateway_rest_api.default.name
+  resource_path    = each.value["path"]
+  http_method      = each.value["method"]
+  api_key_required = each.value["require_api_key"]
+  stage_name       = "default"
+  function_name    = var.lambda_function_name
+  function_alias   = var.lambda_function_alias
+}

--- a/aws/apigw/rest-api/interface.tf
+++ b/aws/apigw/rest-api/interface.tf
@@ -1,0 +1,48 @@
+variable "name" {
+  type     = string
+  nullable = false
+}
+
+variable "tags" {
+  type     = map(string)
+  nullable = false
+  default  = {}
+}
+
+variable "lambda_function_name" {
+  type     = string
+  nullable = false
+}
+
+variable "lambda_function_alias" {
+  type     = string
+  nullable = true
+  default  = null
+}
+
+variable "flags" {
+  default  = {}
+  nullable = false
+  type = object({
+    disable_default_endpoint = optional(bool, true)
+    create_lambda_permission = optional(bool, true)
+  })
+}
+
+variable "routes" {
+  # NOTE: route paths must be at the root level for now
+  type = list(object({
+    method          = string
+    path            = string
+    require_api_key = optional(bool, false)
+  }))
+}
+
+# output
+output "api_id" {
+  value = aws_api_gateway_rest_api.default.id
+}
+
+output "stage_name" {
+  value = aws_api_gateway_stage.default.stage_name
+}

--- a/aws/apigw/rest-api/lambda-integration/default.tf
+++ b/aws/apigw/rest-api/lambda-integration/default.tf
@@ -1,0 +1,25 @@
+resource "aws_api_gateway_method" "default" {
+  rest_api_id      = local.rest_api_id
+  resource_id      = local.resource_id
+  http_method      = upper(var.http_method)
+  authorization    = "NONE"
+  api_key_required = var.api_key_required
+}
+
+resource "aws_api_gateway_integration" "default" {
+  rest_api_id             = aws_api_gateway_method.default.rest_api_id
+  resource_id             = aws_api_gateway_method.default.resource_id
+  http_method             = aws_api_gateway_method.default.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = local.lambda_invoke_arn
+}
+
+resource "aws_lambda_permission" "default" {
+  for_each      = toset([var.stage_name, "test-invoke-stage"])
+  action        = "lambda:InvokeFunction"
+  function_name = var.function_name
+  qualifier     = var.function_alias
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${local.rest_api_exec_arn}/${each.value}/${aws_api_gateway_method.default.http_method}${local.resource_path}"
+}

--- a/aws/apigw/rest-api/lambda-integration/interface.tf
+++ b/aws/apigw/rest-api/lambda-integration/interface.tf
@@ -1,0 +1,40 @@
+variable "rest_api_name" {
+  type     = string
+  nullable = false
+}
+
+variable "resource_path" {
+  type     = string
+  nullable = false
+  validation {
+    condition     = length(var.resource_path) > 0 && substr(var.resource_path, 0, 1) == "/"
+    error_message = "The resource_path value must start with /."
+  }
+}
+
+variable "http_method" {
+  type     = string
+  nullable = false
+}
+
+variable "api_key_required" {
+  type     = bool
+  nullable = false
+  default  = true
+}
+
+variable "function_name" {
+  type     = string
+  nullable = false
+}
+
+variable "function_alias" {
+  type     = string
+  nullable = true
+  default  = null
+}
+
+variable "stage_name" {
+  type     = string
+  nullable = false
+}

--- a/aws/apigw/rest-api/lambda-integration/support.tf
+++ b/aws/apigw/rest-api/lambda-integration/support.tf
@@ -1,0 +1,33 @@
+data "aws_region" "default" {}
+data "aws_caller_identity" "default" {}
+
+locals {
+  region     = data.aws_region.default.name
+  account_id = data.aws_caller_identity.default.account_id
+}
+
+data "aws_api_gateway_rest_api" "default" {
+  name = var.rest_api_name
+}
+
+data "aws_api_gateway_resource" "default" {
+  # NOTE: path must be prefixed with "/"
+  rest_api_id = local.rest_api_id
+  path        = var.resource_path
+}
+
+locals {
+  rest_api_id       = data.aws_api_gateway_rest_api.default.id
+  rest_api_exec_arn = data.aws_api_gateway_rest_api.default.execution_arn
+  resource_id       = data.aws_api_gateway_resource.default.id
+  resource_path     = data.aws_api_gateway_resource.default.path
+}
+
+locals {
+  # lambda_invoke_arn = data.aws_lambda_function.default.invoke_arn
+  # NOTE: building lambda invoke arn manually to avoid version / qualifier suffix
+  integration_uri_prefix = "arn:aws:apigateway:${local.region}:lambda:path/2015-03-31/functions"
+  lambda_arn_parts       = compact(["arn", "aws", "lambda", local.region, local.account_id, "function", var.function_name, var.function_alias])
+  lambda_arn             = join(":", local.lambda_arn_parts) # "arn:aws:lambda:${local.region}:${local.account_id}:function:${var.function_name}"
+  lambda_invoke_arn      = "${local.integration_uri_prefix}/${local.lambda_arn}/invocations"
+}

--- a/aws/apigw/rest-api/readme.md
+++ b/aws/apigw/rest-api/readme.md
@@ -1,0 +1,15 @@
+#### Example
+```terraform
+module "test-api" {
+  source                = "path/to/rest-api"
+  name                  = "test-api"
+  lambda_function_name  = "test-lambda"
+  lambda_function_alias = "latest" # optional
+  routes = [
+    { method = "get",    path = "/{proxy+}", require_api_key = true },
+    { method = "post",   path = "/{proxy+}", require_api_key = true },
+    { method = "put",    path = "/{proxy+}", require_api_key = true },
+    { method = "delete", path = "/{proxy+}", require_api_key = true }
+  ]
+}
+```


### PR DESCRIPTION
## Description
This PR updates the http-api module and adds a port for rest-api.

### HTTP API Changes
- [x] improve nested variables with `optional` object types
- [x] support integration against lambda alias
- [x] support CORS and access logging
- [x] replace `$default` route with `/{proxy+}` for `allowed_methods`
- [x] support extra routes
  - useful for OpenAPI docs
  - useful for Role Based Access Control (RBAC) or requiring certain scopes for routes
- [x] improve example in readme

### Note on Rest API
The underlying `aws_api_gateway_resource` within the module needs to define the parent and path part for each route.
So for simplicity the defined routes cannot have `/` in the middle. It should be possible to support nested routes in a future PR if needed.