### PR TITLE
lambda layer

### DIFF
--- a/aws/lambda/layer/default.tf
+++ b/aws/lambda/layer/default.tf
@@ -3,7 +3,6 @@ resource "aws_lambda_layer_version" "default" {
   compatible_runtimes      = var.runtimes
   compatible_architectures = var.architectures
   filename                 = data.archive_file.default.output_path
-  #  source_code_hash = data.archive_file.default.output_base64sha256
 }
 
 data "archive_file" "default" {

--- a/aws/lambda/layer/default.tf
+++ b/aws/lambda/layer/default.tf
@@ -2,6 +2,8 @@ resource "aws_lambda_layer_version" "default" {
   layer_name               = var.name
   compatible_runtimes      = var.runtimes
   compatible_architectures = var.architectures
+  filename                 = data.archive_file.default.output_path
+  #  source_code_hash = data.archive_file.default.output_base64sha256
 }
 
 data "archive_file" "default" {

--- a/aws/lambda/layer/default.tf
+++ b/aws/lambda/layer/default.tf
@@ -1,0 +1,11 @@
+resource "aws_lambda_layer_version" "default" {
+  layer_name               = var.name
+  compatible_runtimes      = var.runtimes
+  compatible_architectures = var.architectures
+}
+
+data "archive_file" "default" {
+  type        = "zip"
+  source_dir  = "${path.module}/templates/${var.template}"
+  output_path = "${path.module}/local/${var.template}.zip"
+}

--- a/aws/lambda/layer/default.tf
+++ b/aws/lambda/layer/default.tf
@@ -3,6 +3,7 @@ resource "aws_lambda_layer_version" "default" {
   compatible_runtimes      = var.runtimes
   compatible_architectures = var.architectures
   filename                 = data.archive_file.default.output_path
+  description              = var.description
 }
 
 data "archive_file" "default" {

--- a/aws/lambda/layer/interface.tf
+++ b/aws/lambda/layer/interface.tf
@@ -1,0 +1,24 @@
+variable "name" {
+  type     = string
+  nullable = false
+}
+
+variable "runtimes" {
+  type     = list(string)
+  nullable = false
+}
+
+variable "architectures" {
+  type     = list(string)
+  nullable = false
+}
+
+variable "template" {
+  type     = string
+  nullable = false
+  default  = "shell"
+}
+
+output "output" {
+  value = aws_lambda_layer_version.default
+}

--- a/aws/lambda/layer/interface.tf
+++ b/aws/lambda/layer/interface.tf
@@ -19,6 +19,12 @@ variable "template" {
   default  = "shell"
 }
 
+variable "description" {
+  type     = string
+  nullable = true
+  default  = null
+}
+
 output "output" {
   value = aws_lambda_layer_version.default
 }

--- a/aws/lambda/layer/readme.md
+++ b/aws/lambda/layer/readme.md
@@ -1,0 +1,9 @@
+#### Example
+```terraform
+module "test-lambda-layer" {
+  source        = "path/to/lambda/layer"
+  name          = "test-lambda-layer"
+  runtimes      = ["python3.11"]
+  architectures = ["arm64"]
+}
+```

--- a/aws/lambda/layer/templates/shell/bin/hello.sh
+++ b/aws/lambda/layer/templates/shell/bin/hello.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+echo hello world


### PR DESCRIPTION
## Description
This PR adds support to provision lambda layer placeholder resources so that we can define that the layer should be attached to corresponding lambda functions. After the layer is provisioned, updates to the layer and function integration need to be managed with another system. The layer and function modules do not keep track of the `package.zip` data.