### PR TITLE
first pass at MongoDB Atlas via AWS

### DIFF
--- a/aws/util/template/default.tf
+++ b/aws/util/template/default.tf
@@ -1,0 +1,17 @@
+locals {
+  template_path = "${path.module}/local/template.tftpl"
+}
+
+resource local_file "default" {
+  filename = local.template_path
+  content = var.template
+}
+
+data "local_file" "default" {
+  depends_on = [local_file.default]
+  filename = local.template_path
+}
+
+locals {
+  rendered = templatefile(data.local_file.default.filename, var.params)
+}

--- a/aws/util/template/interface.tf
+++ b/aws/util/template/interface.tf
@@ -1,0 +1,17 @@
+variable "template" {
+  type = string
+  nullable = false
+}
+
+variable "params" {
+  type = map(string)
+  nullable = false
+}
+
+output "rendered" {
+  value = local.rendered
+}
+
+output "params" {
+  value = var.params
+}

--- a/aws/util/template/readme.md
+++ b/aws/util/template/readme.md
@@ -1,0 +1,2 @@
+## GitHub Issue for Template Function
+- https://github.com/hashicorp/terraform/issues/30616

--- a/mongodb/aws/atlas/access/default.tf
+++ b/mongodb/aws/atlas/access/default.tf
@@ -1,24 +1,24 @@
-resource "mongodbatlas_project_ip_access_list" "default" {
-  for_each   = { for item in var.ingress_sources : item.source => item }
-  project_id = local.atlas_project_id
-  cidr_block = each.value.source
-  comment    = each.value.comment
-}
-
-data "aws_iam_roles" "admin-sso" {
-  path_prefix = "/aws-reserved/sso.amazonaws.com/"
-  name_regex  = ".*AdministratorAccess.*"
+resource "mongodbatlas_database_user" "admin-sso" {
+  for_each           = var.create_admin ? local.aws_admin_roles : {}
+  project_id         = local.project_id
+  auth_database_name = "$external"
+  aws_iam_type       = upper("role")
+  username           = each.value
+  roles {
+    role_name     = "readWriteAnyDatabase"
+    database_name = "admin"
+  }
 }
 
 resource "mongodbatlas_database_user" "default" {
   for_each           = local.aws_role_ids
-  project_id         = local.atlas_project_id
+  project_id         = local.project_id
   auth_database_name = "$external"
   aws_iam_type       = upper("role")
   username           = each.value
   scopes {
     type = upper("cluster")
-    name = var.atlas_cluster
+    name = var.cluster
   }
   dynamic "roles" {
     for_each = local.rules_by_role[each.key]
@@ -28,4 +28,11 @@ resource "mongodbatlas_database_user" "default" {
       collection_name = roles.value.collection
     }
   }
+}
+
+resource "mongodbatlas_project_ip_access_list" "default" {
+  for_each   = { for item in var.ingress_sources : item.source => item }
+  project_id = local.project_id
+  cidr_block = each.value.source
+  comment    = each.value.comment
 }

--- a/mongodb/aws/atlas/access/default.tf
+++ b/mongodb/aws/atlas/access/default.tf
@@ -1,0 +1,31 @@
+resource "mongodbatlas_project_ip_access_list" "default" {
+  for_each   = { for item in var.ingress_sources : item.source => item }
+  project_id = local.atlas_project_id
+  cidr_block = each.value.source
+  comment    = each.value.comment
+}
+
+data "aws_iam_roles" "admin-sso" {
+  path_prefix = "/aws-reserved/sso.amazonaws.com/"
+  name_regex  = ".*AdministratorAccess.*"
+}
+
+resource "mongodbatlas_database_user" "default" {
+  for_each           = local.aws_role_ids
+  project_id         = local.atlas_project_id
+  auth_database_name = "$external"
+  aws_iam_type       = upper("role")
+  username           = each.value
+  scopes {
+    type = upper("cluster")
+    name = var.atlas_cluster
+  }
+  dynamic "roles" {
+    for_each = local.rules_by_role[each.key]
+    content {
+      role_name       = roles.value.access
+      database_name   = roles.value.database
+      collection_name = roles.value.collection
+    }
+  }
+}

--- a/mongodb/aws/atlas/access/default.tf
+++ b/mongodb/aws/atlas/access/default.tf
@@ -1,3 +1,4 @@
+# TODO: revisit for_each error
 resource "mongodbatlas_database_user" "admin-sso" {
   for_each           = var.create_admin ? local.aws_admin_roles : {}
   project_id         = local.project_id

--- a/mongodb/aws/atlas/access/default.tf
+++ b/mongodb/aws/atlas/access/default.tf
@@ -1,4 +1,5 @@
 resource "mongodbatlas_database_user" "admin-sso" {
+  depends_on = [data.aws_iam_roles.admin-sso]
   for_each           = var.create_admin ? local.aws_admin_roles : {}
   project_id         = local.project_id
   auth_database_name = "$external"

--- a/mongodb/aws/atlas/access/default.tf
+++ b/mongodb/aws/atlas/access/default.tf
@@ -1,5 +1,4 @@
 resource "mongodbatlas_database_user" "admin-sso" {
-  depends_on = [data.aws_iam_roles.admin-sso]
   for_each           = var.create_admin ? local.aws_admin_roles : {}
   project_id         = local.project_id
   auth_database_name = "$external"

--- a/mongodb/aws/atlas/access/interface.tf
+++ b/mongodb/aws/atlas/access/interface.tf
@@ -38,12 +38,12 @@ variable "ingress_sources" {
 
 variable "role_prefix" {
   type     = string
-  nullable = false
+  nullable = true
   default  = null
 }
 
 variable "role_suffix" {
   type     = string
-  nullable = false
+  nullable = true
   default  = null
 }

--- a/mongodb/aws/atlas/access/interface.tf
+++ b/mongodb/aws/atlas/access/interface.tf
@@ -1,0 +1,25 @@
+variable "create_atlas_admin" {
+  type     = bool
+  nullable = false
+  default  = false
+}
+
+variable "ingress_sources" {
+  default  = []
+  nullable = false
+  type = set(object({
+    source  = string
+    comment = string
+  }))
+}
+
+variable "access_rules" {
+  default  = []
+  nullable = false
+  type = set(object({
+    role       = string
+    database   = string
+    collection = string
+    access     = string
+  }))
+}

--- a/mongodb/aws/atlas/access/interface.tf
+++ b/mongodb/aws/atlas/access/interface.tf
@@ -25,18 +25,6 @@ variable "access_rules" {
   }))
 }
 
-variable "role_prefix" {
-  type     = string
-  nullable = true
-  default  = null
-}
-
-variable "role_suffix" {
-  type     = string
-  nullable = true
-  default  = null
-}
-
 variable "ingress_sources" {
   default  = []
   nullable = false
@@ -44,4 +32,18 @@ variable "ingress_sources" {
     source  = string
     comment = string
   }))
+}
+
+# TODO: adopt role_template and role_template_params if template function becomes available
+
+variable "role_prefix" {
+  type     = string
+  nullable = false
+  default  = null
+}
+
+variable "role_suffix" {
+  type     = string
+  nullable = false
+  default  = null
 }

--- a/mongodb/aws/atlas/access/interface.tf
+++ b/mongodb/aws/atlas/access/interface.tf
@@ -1,16 +1,17 @@
-variable "create_atlas_admin" {
+variable "project" {
+  type     = string
+  nullable = false
+}
+
+variable "cluster" {
+  type     = string
+  nullable = false
+}
+
+variable "create_admin" {
   type     = bool
   nullable = false
   default  = false
-}
-
-variable "ingress_sources" {
-  default  = []
-  nullable = false
-  type = set(object({
-    source  = string
-    comment = string
-  }))
 }
 
 variable "access_rules" {
@@ -21,5 +22,26 @@ variable "access_rules" {
     database   = string
     collection = string
     access     = string
+  }))
+}
+
+variable "role_prefix" {
+  type     = string
+  nullable = true
+  default  = null
+}
+
+variable "role_suffix" {
+  type     = string
+  nullable = true
+  default  = null
+}
+
+variable "ingress_sources" {
+  default  = []
+  nullable = false
+  type = set(object({
+    source  = string
+    comment = string
   }))
 }

--- a/mongodb/aws/atlas/access/provider.tf
+++ b/mongodb/aws/atlas/access/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+    }
+  }
+}

--- a/mongodb/aws/atlas/access/support.tf
+++ b/mongodb/aws/atlas/access/support.tf
@@ -1,0 +1,31 @@
+data "mongodbatlas_project" "default" {
+  name = var.project
+}
+
+locals {
+  project_id = data.mongodbatlas_project.default.id
+}
+
+data "aws_iam_roles" "admin-sso" {
+  path_prefix = "/aws-reserved/sso.amazonaws.com/"
+  name_regex  = ".*AdministratorAccess.*"
+}
+
+locals {
+  # aws_admin_roles = zipmap(tolist(data.aws_iam_roles.admin-sso.names), tolist(data.aws_iam_roles.admin-sso.arns))
+  aws_admin_roles = { for arn in data.aws_iam_roles.admin-sso.arns : reverse(split("/", arn))[0] => arn }
+}
+
+locals {
+  access_roles = toset([for rule in var.access_rules : rule.role])
+}
+
+data "aws_iam_role" "default" {
+  for_each = local.access_roles
+  name     = join("", compact([var.role_prefix, each.value, var.role_suffix]))
+}
+
+locals {
+  aws_role_ids  = zipmap(keys(data.aws_iam_role.default), values(data.aws_iam_role.default)[*].arn)
+  rules_by_role = { for role, id in local.aws_role_ids : role => [for rule in var.access_rules : rule if rule.role == role] }
+}

--- a/mongodb/aws/constructs/atlas/access.tf
+++ b/mongodb/aws/constructs/atlas/access.tf
@@ -1,6 +1,7 @@
 module "access" {
   depends_on      = [mongodbatlas_serverless_instance.serverless, mongodbatlas_advanced_cluster.advanced]
   source          = "../../atlas/access"
+  providers       = { mongodbatlas = mongodbatlas.default }
   project         = var.atlas_project
   cluster         = var.atlas_cluster
   create_admin    = var.flags.create_admin

--- a/mongodb/aws/constructs/atlas/access.tf
+++ b/mongodb/aws/constructs/atlas/access.tf
@@ -1,0 +1,9 @@
+module "access" {
+  depends_on      = [mongodbatlas_serverless_instance.serverless, mongodbatlas_advanced_cluster.advanced]
+  source          = "../../atlas/access"
+  project         = var.atlas_project
+  cluster         = var.atlas_cluster
+  create_admin    = var.flags.create_admin
+  access_rules    = var.access_rules
+  ingress_sources = var.ingress_sources
+}

--- a/mongodb/aws/constructs/atlas/access.tf
+++ b/mongodb/aws/constructs/atlas/access.tf
@@ -6,4 +6,6 @@ module "access" {
   create_admin    = var.flags.create_admin
   access_rules    = var.access_rules
   ingress_sources = var.ingress_sources
+  role_prefix     = var.flags.role_prefix
+  role_suffix     = var.flags.role_suffix
 }

--- a/mongodb/aws/constructs/atlas/access.tf
+++ b/mongodb/aws/constructs/atlas/access.tf
@@ -13,6 +13,6 @@ module "access" {
 locals {
   default_role_prefix = "${var.project}-"
   default_role_suffix = "-${var.environment}-${var.namespace}"
-  role_prefix = var.flags.render_role ? coalesce(var.flags.role_prefix, local.default_role_prefix) : null
-  role_suffix = var.flags.render_role ? coalesce(var.flags.role_suffix, local.default_role_suffix) : null
+  role_prefix         = var.flags.render_role ? coalesce(var.flags.role_prefix, local.default_role_prefix) : null
+  role_suffix         = var.flags.render_role ? coalesce(var.flags.role_suffix, local.default_role_suffix) : null
 }

--- a/mongodb/aws/constructs/atlas/access.tf
+++ b/mongodb/aws/constructs/atlas/access.tf
@@ -6,6 +6,13 @@ module "access" {
   create_admin    = var.flags.create_admin
   access_rules    = var.access_rules
   ingress_sources = var.ingress_sources
-  role_prefix     = var.flags.role_prefix
-  role_suffix     = var.flags.role_suffix
+  role_prefix     = local.role_prefix
+  role_suffix     = local.role_suffix
+}
+
+locals {
+  default_role_prefix = "${var.project}-"
+  default_role_suffix = "-${var.environment}-${var.namespace}"
+  role_prefix = var.flags.render_role ? coalesce(var.flags.role_prefix, local.default_role_prefix) : null
+  role_suffix = var.flags.render_role ? coalesce(var.flags.role_suffix, local.default_role_suffix) : null
 }

--- a/mongodb/aws/constructs/atlas/access.tf
+++ b/mongodb/aws/constructs/atlas/access.tf
@@ -1,7 +1,6 @@
 module "access" {
   depends_on      = [mongodbatlas_serverless_instance.serverless, mongodbatlas_advanced_cluster.advanced]
   source          = "../../atlas/access"
-  providers       = { mongodbatlas = mongodbatlas.default }
   project         = var.atlas_project
   cluster         = var.atlas_cluster
   create_admin    = var.flags.create_admin

--- a/mongodb/aws/constructs/atlas/default.tf
+++ b/mongodb/aws/constructs/atlas/default.tf
@@ -17,11 +17,12 @@ resource "mongodbatlas_serverless_instance" "serverless" {
 }
 
 resource "mongodbatlas_advanced_cluster" "advanced" {
-  count          = contains(["shared"], var.cluster_type) ? 1 : 0
-  project_id     = local.atlas_project_id
-  name           = var.atlas_cluster
-  cluster_type   = upper("replicaset")
-  backup_enabled = false
+  count                          = contains(["shared"], var.cluster_type) ? 1 : 0
+  project_id                     = local.atlas_project_id
+  name                           = var.atlas_cluster
+  cluster_type                   = upper("replicaset")
+  backup_enabled                 = var.flags.backup
+  termination_protection_enabled = var.flags.termination_protection
 
   replication_specs {
     region_configs {

--- a/mongodb/aws/constructs/atlas/default.tf
+++ b/mongodb/aws/constructs/atlas/default.tf
@@ -1,0 +1,41 @@
+locals {
+  atlas_region     = upper(replace(var.region, "-", "_"))
+  atlas_project_id = data.mongodbatlas_project.default.id
+}
+
+data "mongodbatlas_project" "default" {
+  name = var.atlas_project
+}
+
+resource "mongodbatlas_serverless_instance" "serverless" {
+  count = var.cluster_type == "serverless" ? 1:0
+  project_id                              = local.atlas_project_id
+  name                                    = var.atlas_cluster
+  provider_settings_backing_provider_name = upper("aws")
+  provider_settings_provider_name         = upper("serverless")
+  provider_settings_region_name           = local.atlas_region
+}
+
+resource "mongodbatlas_advanced_cluster" "advanced" {
+  count = contains(["shared"], var.cluster_type) ? 1:0
+  project_id   = local.atlas_project_id
+  name         = var.atlas_cluster
+  cluster_type = upper("replicaset")
+  backup_enabled = false
+
+  replication_specs {
+    region_configs {
+      priority      = 0
+      provider_name = upper("aws")
+      region_name   = local.atlas_region
+    }
+  }
+
+  dynamic tags {
+    for_each = local.common_tags
+    content {
+      key = tags.key
+      value = tags.value
+    }
+  }
+}

--- a/mongodb/aws/constructs/atlas/default.tf
+++ b/mongodb/aws/constructs/atlas/default.tf
@@ -25,9 +25,10 @@ resource "mongodbatlas_advanced_cluster" "advanced" {
 
   replication_specs {
     region_configs {
-      priority      = 0
-      provider_name = upper("aws")
-      region_name   = local.atlas_region
+      priority              = 0
+      provider_name         = upper("tenant")
+      backing_provider_name = upper("aws")
+      region_name           = local.atlas_region
       electable_specs {
         instance_size = "M0"
       }

--- a/mongodb/aws/constructs/atlas/default.tf
+++ b/mongodb/aws/constructs/atlas/default.tf
@@ -8,7 +8,7 @@ data "mongodbatlas_project" "default" {
 }
 
 resource "mongodbatlas_serverless_instance" "serverless" {
-  count                                   = var.cluster_type == "serverless" ? 1 : 0
+  count                                   = local.create_serverless ? 1 : 0
   project_id                              = local.atlas_project_id
   name                                    = var.atlas_cluster
   provider_settings_backing_provider_name = upper("aws")
@@ -25,7 +25,7 @@ resource "mongodbatlas_serverless_instance" "serverless" {
 }
 
 resource "mongodbatlas_advanced_cluster" "advanced" {
-  count                          = contains(["shared"], var.cluster_type) ? 1 : 0
+  count                          = local.create_advanced ? 1 : 0
   project_id                     = local.atlas_project_id
   name                           = var.atlas_cluster
   cluster_type                   = upper("replicaset")

--- a/mongodb/aws/constructs/atlas/default.tf
+++ b/mongodb/aws/constructs/atlas/default.tf
@@ -14,6 +14,14 @@ resource "mongodbatlas_serverless_instance" "serverless" {
   provider_settings_backing_provider_name = upper("aws")
   provider_settings_provider_name         = upper("serverless")
   provider_settings_region_name           = local.atlas_region
+
+  dynamic "tags" {
+    for_each = local.common_tags
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
 }
 
 resource "mongodbatlas_advanced_cluster" "advanced" {

--- a/mongodb/aws/constructs/atlas/default.tf
+++ b/mongodb/aws/constructs/atlas/default.tf
@@ -8,7 +8,7 @@ data "mongodbatlas_project" "default" {
 }
 
 resource "mongodbatlas_serverless_instance" "serverless" {
-  count = var.cluster_type == "serverless" ? 1:0
+  count                                   = var.cluster_type == "serverless" ? 1 : 0
   project_id                              = local.atlas_project_id
   name                                    = var.atlas_cluster
   provider_settings_backing_provider_name = upper("aws")
@@ -17,10 +17,10 @@ resource "mongodbatlas_serverless_instance" "serverless" {
 }
 
 resource "mongodbatlas_advanced_cluster" "advanced" {
-  count = contains(["shared"], var.cluster_type) ? 1:0
-  project_id   = local.atlas_project_id
-  name         = var.atlas_cluster
-  cluster_type = upper("replicaset")
+  count          = contains(["shared"], var.cluster_type) ? 1 : 0
+  project_id     = local.atlas_project_id
+  name           = var.atlas_cluster
+  cluster_type   = upper("replicaset")
   backup_enabled = false
 
   replication_specs {
@@ -31,10 +31,10 @@ resource "mongodbatlas_advanced_cluster" "advanced" {
     }
   }
 
-  dynamic tags {
+  dynamic "tags" {
     for_each = local.common_tags
     content {
-      key = tags.key
+      key   = tags.key
       value = tags.value
     }
   }

--- a/mongodb/aws/constructs/atlas/default.tf
+++ b/mongodb/aws/constructs/atlas/default.tf
@@ -25,9 +25,10 @@ resource "mongodbatlas_advanced_cluster" "advanced" {
 
   replication_specs {
     region_configs {
-      priority      = 7
-      provider_name = upper("tenant")
-      region_name   = local.atlas_region
+      priority              = 0
+      provider_name         = upper("tenant")
+      backing_provider_name = upper("aws")
+      region_name           = local.atlas_region
       electable_specs {
         instance_size = "M0"
       }

--- a/mongodb/aws/constructs/atlas/default.tf
+++ b/mongodb/aws/constructs/atlas/default.tf
@@ -25,7 +25,7 @@ resource "mongodbatlas_advanced_cluster" "advanced" {
 
   replication_specs {
     region_configs {
-      priority              = 0
+      priority              = 7
       provider_name         = upper("tenant")
       backing_provider_name = upper("aws")
       region_name           = local.atlas_region

--- a/mongodb/aws/constructs/atlas/default.tf
+++ b/mongodb/aws/constructs/atlas/default.tf
@@ -28,6 +28,9 @@ resource "mongodbatlas_advanced_cluster" "advanced" {
       priority      = 0
       provider_name = upper("aws")
       region_name   = local.atlas_region
+      electable_specs {
+        instance_size = "M0"
+      }
     }
   }
 

--- a/mongodb/aws/constructs/atlas/default.tf
+++ b/mongodb/aws/constructs/atlas/default.tf
@@ -25,10 +25,9 @@ resource "mongodbatlas_advanced_cluster" "advanced" {
 
   replication_specs {
     region_configs {
-      priority              = 0
-      provider_name         = upper("tenant")
-      backing_provider_name = upper("aws")
-      region_name           = local.atlas_region
+      priority      = 7
+      provider_name = upper("tenant")
+      region_name   = local.atlas_region
       electable_specs {
         instance_size = "M0"
       }

--- a/mongodb/aws/constructs/atlas/interface.tf
+++ b/mongodb/aws/constructs/atlas/interface.tf
@@ -1,0 +1,36 @@
+# general
+variable "account" { type = string }
+variable "project" { type = string }
+variable "owner" { type = string }
+variable "namespace" { type = string }
+
+variable "account_id" { type = string }
+variable "environment" { type = string }
+variable "region" { type = string }
+variable "default_region" { type = string }
+
+# module
+variable "atlas_project" {
+  type     = string
+  nullable = false
+}
+
+variable "atlas_cluster" {
+  type     = string
+  nullable = false
+}
+
+variable "cluster_type" {
+  type = string
+  nullable = false
+  validation {
+    # TODO: add support for dedicated
+    condition     = contains(["shared", "serverless"], var.cluster_type)
+    error_message = "Allowed Values: cluster_type -> {shared, serverless}."
+  }
+}
+
+# output
+#output "public_host" {
+#  value = local.public_atlas_host
+#}

--- a/mongodb/aws/constructs/atlas/interface.tf
+++ b/mongodb/aws/constructs/atlas/interface.tf
@@ -30,6 +30,15 @@ variable "cluster_type" {
   }
 }
 
+variable "flags" {
+  default  = {}
+  nullable = false
+  type = object({
+    backup                 = optional(bool, false)
+    termination_protection = optional(bool, false)
+  })
+}
+
 # output
 #output "public_host" {
 #  value = local.public_atlas_host

--- a/mongodb/aws/constructs/atlas/interface.tf
+++ b/mongodb/aws/constructs/atlas/interface.tf
@@ -21,7 +21,7 @@ variable "atlas_cluster" {
 }
 
 variable "cluster_type" {
-  type = string
+  type     = string
   nullable = false
   validation {
     # TODO: add support for dedicated

--- a/mongodb/aws/constructs/atlas/interface.tf
+++ b/mongodb/aws/constructs/atlas/interface.tf
@@ -37,9 +37,9 @@ variable "flags" {
     backup                 = optional(bool, false)
     termination_protection = optional(bool, false)
     create_admin           = optional(bool, false)
-    render_role = optional(bool, true)
-    role_prefix = optional(string)
-    role_suffix = optional(string)
+    render_role            = optional(bool, true)
+    role_prefix            = optional(string)
+    role_suffix            = optional(string)
   })
 }
 

--- a/mongodb/aws/constructs/atlas/interface.tf
+++ b/mongodb/aws/constructs/atlas/interface.tf
@@ -36,10 +36,31 @@ variable "flags" {
   type = object({
     backup                 = optional(bool, false)
     termination_protection = optional(bool, false)
+    create_admin           = optional(bool, false)
   })
 }
 
+variable "access_rules" {
+  default  = []
+  nullable = false
+  type = set(object({
+    role       = string
+    database   = string
+    collection = string
+    access     = string
+  }))
+}
+
+variable "ingress_sources" {
+  default  = []
+  nullable = false
+  type = set(object({
+    source  = string
+    comment = string
+  }))
+}
+
 # output
-#output "public_host" {
-#  value = local.public_atlas_host
-#}
+output "public_host" {
+  value = local.public_atlas_host
+}

--- a/mongodb/aws/constructs/atlas/interface.tf
+++ b/mongodb/aws/constructs/atlas/interface.tf
@@ -37,8 +37,9 @@ variable "flags" {
     backup                 = optional(bool, false)
     termination_protection = optional(bool, false)
     create_admin           = optional(bool, false)
-    role_prefix            = optional(string)
-    role_suffix            = optional(string)
+    render_role = optional(bool, true)
+    role_prefix = optional(string)
+    role_suffix = optional(string)
   })
 }
 

--- a/mongodb/aws/constructs/atlas/interface.tf
+++ b/mongodb/aws/constructs/atlas/interface.tf
@@ -37,6 +37,8 @@ variable "flags" {
     backup                 = optional(bool, false)
     termination_protection = optional(bool, false)
     create_admin           = optional(bool, false)
+    role_prefix            = optional(string)
+    role_suffix            = optional(string)
   })
 }
 

--- a/mongodb/aws/constructs/atlas/locals.tf
+++ b/mongodb/aws/constructs/atlas/locals.tf
@@ -18,8 +18,8 @@ locals {
 locals {
   standard_connection = compact(local._standard_connection_list)[0]
   _standard_connection_list = [
-    local.create_serverless ? mongodbatlas_serverless_instance.serverless[0].connection_strings_standard_srv[1] : null,
-    local.create_advanced ? mongodbatlas_advanced_cluster.advanced[0].connection : null
+    local.create_serverless ? mongodbatlas_serverless_instance.serverless[0].connection_strings_standard_srv : null,
+    local.create_advanced ? mongodbatlas_advanced_cluster.advanced[0].connection_strings[0].standard_srv : null
   ]
 }
 

--- a/mongodb/aws/constructs/atlas/locals.tf
+++ b/mongodb/aws/constructs/atlas/locals.tf
@@ -1,0 +1,11 @@
+locals {
+  common_tags = {
+    account     = var.account
+    project     = var.project
+    owner       = var.owner
+    namespace   = var.namespace
+    environment = var.environment
+    region      = var.region
+    managed     = "terraform"
+  }
+}

--- a/mongodb/aws/constructs/atlas/locals.tf
+++ b/mongodb/aws/constructs/atlas/locals.tf
@@ -11,8 +11,8 @@ locals {
 }
 
 locals {
-  create_serverless = var.cluster_type == "serverless" ? 1 : 0
-  create_advanced   = contains(["shared"], var.cluster_type) ? 1 : 0
+  create_serverless = var.cluster_type == "serverless"
+  create_advanced   = contains(["shared"], var.cluster_type)
 }
 
 locals {

--- a/mongodb/aws/constructs/atlas/locals.tf
+++ b/mongodb/aws/constructs/atlas/locals.tf
@@ -9,3 +9,20 @@ locals {
     managed     = "terraform"
   }
 }
+
+locals {
+  create_serverless = var.cluster_type == "serverless" ? 1 : 0
+  create_advanced   = contains(["shared"], var.cluster_type) ? 1 : 0
+}
+
+locals {
+  standard_connection = compact(local._standard_connection_list)[0]
+  _standard_connection_list = [
+    local.create_serverless ? mongodbatlas_serverless_instance.serverless[0].connection_strings_standard_srv[1] : null,
+    local.create_advanced ? mongodbatlas_advanced_cluster.advanced[0].connection : null
+  ]
+}
+
+locals {
+  public_atlas_host = split("//", local.standard_connection)
+}

--- a/mongodb/aws/constructs/atlas/locals.tf
+++ b/mongodb/aws/constructs/atlas/locals.tf
@@ -24,5 +24,5 @@ locals {
 }
 
 locals {
-  public_atlas_host = split("//", local.standard_connection)
+  public_atlas_host = split("//", local.standard_connection)[1]
 }

--- a/mongodb/aws/constructs/atlas/provider.tf
+++ b/mongodb/aws/constructs/atlas/provider.tf
@@ -17,7 +17,3 @@ provider "aws" {
   region              = var.region
   allowed_account_ids = [var.account_id]
 }
-
-provider "mongodbatlas" {
-  alias = "default"
-}

--- a/mongodb/aws/constructs/atlas/provider.tf
+++ b/mongodb/aws/constructs/atlas/provider.tf
@@ -18,4 +18,6 @@ provider "aws" {
   allowed_account_ids = [var.account_id]
 }
 
-provider "mongodbatlas" {}
+provider "mongodbatlas" {
+  alias = "default"
+}

--- a/mongodb/aws/constructs/atlas/provider.tf
+++ b/mongodb/aws/constructs/atlas/provider.tf
@@ -17,3 +17,5 @@ provider "aws" {
   region              = var.region
   allowed_account_ids = [var.account_id]
 }
+
+provider "mongodbatlas" {}

--- a/mongodb/aws/constructs/atlas/provider.tf
+++ b/mongodb/aws/constructs/atlas/provider.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "s3" {}
+  required_version = "~> 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    mongodbatlas = {
+      source  = "mongodb/mongodbatlas"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "aws" {
+  region              = var.region
+  allowed_account_ids = [var.account_id]
+}

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@
 ## Additional Notes
 - [Optional object type attributes][optional-object-type] were experimental in terraform 1.2; generally available as of 1.3.
 - [terragrunt-null-issue]
+- [template-function-issue]
 
 ## Changelog
 ### 0.4.0
@@ -23,3 +24,4 @@
 [optional-attributes-experiment]: https://www.terraform.io/language/expressions/type-constraints#experimental-optional-object-type-attributes
 [terragrunt-null-issue]: https://github.com/gruntwork-io/terragrunt/issues/892
 [optional-object-type]: https://developer.hashicorp.com/terraform/language/expressions/type-constraints#optional-object-type-attributes
+[template-function-issue]: https://github.com/hashicorp/terraform/issues/30616

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@
 - add `lambda/layer` module
 
 ### 0.4.2
-- TBD
+- start construct and module for MongoDB Atlas Cluster backed by AWS
 
 [defaults-function]: https://www.terraform.io/language/functions/defaults
 [optional-attributes-experiment]: https://www.terraform.io/language/expressions/type-constraints#experimental-optional-object-type-attributes

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,12 @@
 - remove `network/v1` module and construct; move `network/v2` to `network`
 - add `params/lookup` module
 
+### 0.4.1
+- add `lambda/layer` module
+
+### 0.4.2
+- TBD
+
 [defaults-function]: https://www.terraform.io/language/functions/defaults
 [optional-attributes-experiment]: https://www.terraform.io/language/expressions/type-constraints#experimental-optional-object-type-attributes
 [terragrunt-null-issue]: https://github.com/gruntwork-io/terragrunt/issues/892


### PR DESCRIPTION
## Description
This PR starts support for the MongoDB provider. The construct supports creating either a shared or serverless single region Atlas cluster backed by AWS. And the `access` module manages network and permissions for the cluster.

### Future Work
- [ ] add example usage
- [ ] support dedicated clusters
- [ ] troubleshoot or add note for `create_admin` variable

### Additional Notes
The `access_rules` are meant to reference IAM role names within a project. For example, if you use "fastapi-lambda" as the role name in the rule, that could reference "${var.project}-fastapi-lambda-{var.environment}-${var.namespace}" depending on your naming convention. I was looking to implement, but it doesn't seem like that's supported. Terraform has a `templatefile` but not an equivalent function for working with in memory string templates. And there is a data source with the `template` provider but that has been deprecated in favor of the `templatefile` function.

- https://developer.hashicorp.com/terraform/language/functions/templatefile
- https://registry.terraform.io/providers/hashicorp/template/latest/docs
- https://github.com/hashicorp/terraform/issues/30616