### PR TITLE
first pass at auth0 resource-server module

### DIFF
--- a/auth0/resource-server/default.tf
+++ b/auth0/resource-server/default.tf
@@ -24,13 +24,15 @@ resource "auth0_resource_server_scopes" "default" {
 }
 
 locals {
-  role_map = { for role in var.roles : role.name => role }
+  role_map               = { for role in var.roles : role.name => role }
+  role_enable_prefix_map = { for role in var.roles : role.name => coalesce(role.enable_prefix, var.flags.enable_prefix) }
+  role_delimiter_map     = { for role in var.roles : role.name => coalesce(role.delimiter, var.flags.delimiter) }
 }
 
 module "roles" {
   source      = "../role"
   for_each    = local.role_map
-  name        = "${var.name}${var.flags.delimiter}${each.value.name}"
+  name        = local.role_enable_prefix_map[each.key] ? "${var.name}${local.role_delimiter_map[each.key]}${each.value.name}" : each.value.name
   description = each.value.description
   permissions = { "${auth0_resource_server.default.identifier}" = each.value.scopes }
 }

--- a/auth0/resource-server/default.tf
+++ b/auth0/resource-server/default.tf
@@ -30,7 +30,7 @@ locals {
 module "roles" {
   source      = "../role"
   for_each    = local.role_map
-  name        = "${var.name}/each.value.name"
+  name        = "${var.name}${var.flags.delimiter}${each.value.name}"
   description = each.value.description
   permissions = { "${auth0_resource_server.default.identifier}" = each.value.scopes }
 }

--- a/auth0/resource-server/default.tf
+++ b/auth0/resource-server/default.tf
@@ -1,0 +1,24 @@
+resource "auth0_resource_server" "default" {
+  name                                            = var.name
+  identifier                                      = var.identifier
+  signing_alg                                     = "RS256"
+  token_dialect                                   = local.token_dialect
+  enforce_policies                                = var.flags.enable_rbac
+  allow_offline_access                            = var.flags.allow_offline_access
+  skip_consent_for_verifiable_first_party_clients = var.flags.skip_user_consent
+}
+
+locals {
+  token_dialect = var.flags.include_permissions && var.flags.enable_rbac ? "access_token_authz" : "access_token"
+}
+
+resource "auth0_resource_server_scopes" "default" {
+  resource_server_identifier = auth0_resource_server.default.identifier
+  dynamic "scopes" {
+    for_each = var.scopes
+    content {
+      name        = scopes.key
+      description = scopes.value
+    }
+  }
+}

--- a/auth0/resource-server/default.tf
+++ b/auth0/resource-server/default.tf
@@ -22,3 +22,15 @@ resource "auth0_resource_server_scopes" "default" {
     }
   }
 }
+
+locals {
+  role_map = { for role in var.roles : role.name => role }
+}
+
+module "roles" {
+  source      = "../role"
+  for_each    = local.role_map
+  name        = "${var.name}/each.value.name"
+  description = each.value.description
+  permissions = { auth0_resource_server.default.identifier = each.value.scopes }
+}

--- a/auth0/resource-server/default.tf
+++ b/auth0/resource-server/default.tf
@@ -32,5 +32,5 @@ module "roles" {
   for_each    = local.role_map
   name        = "${var.name}/each.value.name"
   description = each.value.description
-  permissions = { auth0_resource_server.default.identifier = each.value.scopes }
+  permissions = { "${auth0_resource_server.default.identifier}" = each.value.scopes }
 }

--- a/auth0/resource-server/interface.tf
+++ b/auth0/resource-server/interface.tf
@@ -22,4 +22,5 @@ variable "flags" {
 variable "scopes" {
   nullable = false
   type     = map(string)
+  help     = "scope -> description"
 }

--- a/auth0/resource-server/interface.tf
+++ b/auth0/resource-server/interface.tf
@@ -20,9 +20,9 @@ variable "flags" {
 }
 
 variable "scopes" {
-  nullable = false
-  type     = map(string)
-  help     = "scope -> description"
+  nullable    = false
+  type        = map(string)
+  description = "scope -> description"
 }
 
 variable "roles" {

--- a/auth0/resource-server/interface.tf
+++ b/auth0/resource-server/interface.tf
@@ -17,6 +17,7 @@ variable "flags" {
     allow_offline_access = optional(bool, true)
     skip_user_consent    = optional(bool, true)
     delimiter            = optional(string, "/")
+    enable_prefix        = optional(bool, true)
   })
 }
 
@@ -30,8 +31,10 @@ variable "roles" {
   default  = []
   nullable = false
   type = set(object({
-    name        = string
-    description = string
-    scopes      = list(string)
+    name          = string
+    description   = string
+    scopes        = list(string)
+    delimiter     = optional(string)
+    enable_prefix = optional(bool)
   }))
 }

--- a/auth0/resource-server/interface.tf
+++ b/auth0/resource-server/interface.tf
@@ -24,3 +24,13 @@ variable "scopes" {
   type     = map(string)
   help     = "scope -> description"
 }
+
+variable "roles" {
+  default  = []
+  nullable = false
+  type = set(object({
+    name        = string
+    description = string
+    scopes      = list(string)
+  }))
+}

--- a/auth0/resource-server/interface.tf
+++ b/auth0/resource-server/interface.tf
@@ -1,0 +1,25 @@
+variable "name" {
+  type     = string
+  nullable = false
+}
+
+variable "identifier" {
+  type     = string
+  nullable = false
+}
+
+variable "flags" {
+  default  = {}
+  nullable = false
+  type = object({
+    enable_rbac          = optional(bool, true)
+    include_permissions  = optional(bool, false)
+    allow_offline_access = optional(bool, true)
+    skip_user_consent    = optional(bool, true)
+  })
+}
+
+variable "scopes" {
+  nullable = false
+  type     = map(string)
+}

--- a/auth0/resource-server/interface.tf
+++ b/auth0/resource-server/interface.tf
@@ -16,6 +16,7 @@ variable "flags" {
     include_permissions  = optional(bool, false)
     allow_offline_access = optional(bool, true)
     skip_user_consent    = optional(bool, true)
+    delimiter            = optional(string, "/")
   })
 }
 

--- a/auth0/resource-server/provider.tf
+++ b/auth0/resource-server/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    auth0 = {
+      source = "auth0/auth0"
+    }
+  }
+}

--- a/auth0/resource-server/readme.md
+++ b/auth0/resource-server/readme.md
@@ -1,0 +1,16 @@
+#### Example
+```terraform
+module "test-resource-server" {
+  source     = "path/to/resource-server"
+  name       = "test/dev"
+  identifier = "https://api-dev.example.org"
+  scopes = {
+    "message:read"  = "read messages"
+    "message:write" = "write messages"
+    "message:admin" = "admin messages"
+  }
+  roles = [
+    { name = "admin", description = "admin user for test application", scopes = ["message:admin"] }
+  ]
+}
+```

--- a/auth0/role/default.tf
+++ b/auth0/role/default.tf
@@ -1,0 +1,16 @@
+resource "auth0_role" "default" {
+  name        = var.name
+  description = var.description
+}
+
+locals {
+  resource_server_scope_list = flatten([for key, values in var.permissions : [for value in values : { resource_server_identifier = key, scope = value }]])
+  resource_server_scope_map  = { for item in local.resource_server_scope_list : "${item.resource_server_identifier}|${item.scope}" => item }
+}
+
+resource "auth0_role_permission" "default" {
+  for_each                   = local.resource_server_scope_map
+  role_id                    = auth0_role.default.id
+  resource_server_identifier = each.value.resource_server_identifier
+  permission                 = each.value.scope
+}

--- a/auth0/role/interface.tf
+++ b/auth0/role/interface.tf
@@ -9,8 +9,8 @@ variable "description" {
 }
 
 variable "permissions" {
-  type     = map(list(string))
-  nullable = false
-  default  = {}
-  help     = "resource_server_identifier -> scopes"
+  type        = map(list(string))
+  nullable    = false
+  default     = {}
+  description = "resource_server_identifier -> scopes"
 }

--- a/auth0/role/interface.tf
+++ b/auth0/role/interface.tf
@@ -1,0 +1,16 @@
+variable "name" {
+  type     = string
+  nullable = false
+}
+
+variable "description" {
+  type     = string
+  nullable = false
+}
+
+variable "permissions" {
+  type     = map(list(string))
+  nullable = false
+  default  = {}
+  help     = "resource_server_identifier -> scopes"
+}

--- a/auth0/role/provider.tf
+++ b/auth0/role/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    auth0 = {
+      source = "auth0/auth0"
+    }
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,9 @@
 ### 0.4.2
 - start construct and module for MongoDB Atlas Cluster backed by AWS
 
+### 0.4.3
+- start modules for Auth0 `resource-server` and `role`
+
 [defaults-function]: https://www.terraform.io/language/functions/defaults
 [optional-attributes-experiment]: https://www.terraform.io/language/expressions/type-constraints#experimental-optional-object-type-attributes
 [terragrunt-null-issue]: https://github.com/gruntwork-io/terragrunt/issues/892


### PR DESCRIPTION
## Description
This PR starts support the Auth0 provider with two modules. The `role` module encapsulates an auth0 role along with its api permissions or scopes. And the `resource-server` wraps the config for managing the auth0 api alongs with its scopes and optionally the roles you'd want to create for users.

### Future Work
- [ ] add readme to `role` module