### PR TITLE
support allowed_headers for http-api cors

### DIFF
--- a/aws/apigw/http-api/default.tf
+++ b/aws/apigw/http-api/default.tf
@@ -7,7 +7,7 @@ locals {
   enable_jwt_authorizer   = var.flags.enable_jwt_authorizer && var.jwt_auth != null
   lambda_arn_parts        = compact([data.aws_lambda_function.default.arn, var.lambda_function_alias])
   lambda_arn              = join(":", local.lambda_arn_parts)
-  allowed_headers_default = set(var.flags.enable_default_allowed_headers ? ["authorization"] : [])
+  allowed_headers_default = var.flags.enable_default_allowed_headers ? ["authorization"] : []
   allowed_headers         = setunion(var.allowed_headers, local.allowed_headers_default)
 }
 

--- a/aws/apigw/http-api/default.tf
+++ b/aws/apigw/http-api/default.tf
@@ -3,10 +3,12 @@ data "aws_lambda_function" "default" {
 }
 
 locals {
-  enable_cors           = length(var.allowed_origins) > 0
-  enable_jwt_authorizer = var.flags.enable_jwt_authorizer && var.jwt_auth != null
-  lambda_arn_parts      = compact([data.aws_lambda_function.default.arn, var.lambda_function_alias])
-  lambda_arn            = join(":", local.lambda_arn_parts)
+  enable_cors             = length(var.allowed_origins) > 0
+  enable_jwt_authorizer   = var.flags.enable_jwt_authorizer && var.jwt_auth != null
+  lambda_arn_parts        = compact([data.aws_lambda_function.default.arn, var.lambda_function_alias])
+  lambda_arn              = join(":", local.lambda_arn_parts)
+  allowed_headers_default = set(var.flags.enable_default_allowed_headers ? ["authorization"] : [])
+  allowed_headers         = setunion(var.allowed_headers, local.allowed_headers_default)
 }
 
 resource "aws_apigatewayv2_api" "default" {
@@ -20,7 +22,7 @@ resource "aws_apigatewayv2_api" "default" {
     content {
       allow_origins = var.allowed_origins
       allow_methods = var.allowed_methods
-      allow_headers = ["authorization"]
+      allow_headers = local.allowed_headers
     }
   }
 }

--- a/aws/apigw/http-api/interface.tf
+++ b/aws/apigw/http-api/interface.tf
@@ -24,12 +24,13 @@ variable "flags" {
   default  = {}
   nullable = false
   type = object({
-    auto_deploy              = optional(bool, true)
-    disable_default_endpoint = optional(bool, true)
-    create_lambda_permission = optional(bool, true)
-    enable_jwt_authorizer    = optional(bool, true)
-    enable_proxy_route       = optional(bool, true)
-    enable_logs              = optional(bool, true)
+    auto_deploy                    = optional(bool, true)
+    disable_default_endpoint       = optional(bool, true)
+    create_lambda_permission       = optional(bool, true)
+    enable_jwt_authorizer          = optional(bool, true)
+    enable_proxy_route             = optional(bool, true)
+    enable_logs                    = optional(bool, true)
+    enable_default_allowed_headers = optional(bool, true)
   })
 }
 
@@ -50,6 +51,12 @@ variable "allowed_methods" {
 }
 
 variable "allowed_origins" {
+  type     = set(string)
+  default  = []
+  nullable = false
+}
+
+variable "allowed_headers" {
   type     = set(string)
   default  = []
   nullable = false


### PR DESCRIPTION
## Description
While testing the `apigw` / `http-api` module against cors post requests it seems like another header was required in the config: `content-type`. This PR adds more flexibility for the module with two more variables: `allowed_headers` and `flags.enable_default_allowed_headers`. The `authorization` header is included by default.